### PR TITLE
Fix dark mode styling for cards, buttons, and tags

### DIFF
--- a/src/components/ui/Button.astro
+++ b/src/components/ui/Button.astro
@@ -26,8 +26,8 @@ const sizes = {
 };
 
 const styles = {
-  primary: "bg-orange text-white hover:bg-black  border-2 border-transparent",
-  secondary: "bg-black text-white hover:bg-orange  border-2 border-transparent",
+  primary: "bg-orange text-white hover:bg-black dark:hover:bg-white dark:hover:text-black border-2 border-transparent",
+  secondary: "bg-black text-white hover:bg-orange dark:bg-white dark:text-black dark:hover:bg-orange dark:hover:text-white border-2 border-transparent",
 };
 ---
 

--- a/src/components/ui/Card.astro
+++ b/src/components/ui/Card.astro
@@ -39,7 +39,7 @@ const image = imageMap[title];
 <section class="w-full p-4 lg:w-1/3">
   <article
     data-testid="card"
-    class="rounded-xl bg-white p-3 shadow-lg duration-100 hover:scale-105 hover:transform hover:shadow-xl"
+    class="rounded-xl bg-white dark:bg-black p-3 shadow-lg dark:shadow-orange/20 duration-100 hover:scale-105 hover:transform hover:shadow-xl"
   >
     <a href={url} aria-label="link to project">
       <div
@@ -55,7 +55,7 @@ const image = imageMap[title];
       </div>
       <div class="mt-1 p-2">
         <h3 class="text-xl text-orange lg:text-2xl">{title}</h3>
-        <p class="text-black text-s">{description}</p>
+        <p class="text-black dark:text-white text-s">{description}</p>
         <Tags tags={tags} />
       </div>
     </a>

--- a/src/components/ui/Tags.astro
+++ b/src/components/ui/Tags.astro
@@ -10,7 +10,7 @@ const { tags } = Astro.props;
   tags && (
     <div class="mt-2 flex w-2/3 flex-row flex-wrap justify-between">
       {tags.map((tag) => (
-        <span class="inline-block rounded py-2 text-xs text-black  lg:py-1">
+        <span class="inline-block rounded py-2 text-xs text-black dark:text-white lg:py-1">
           #{tag}
         </span>
       ))}

--- a/tests/content.spec.ts
+++ b/tests/content.spec.ts
@@ -34,7 +34,7 @@ test.describe("Page Content", () => {
       const firstCard = page.locator('[data-testid="card"]').first();
       await firstCard.hover();
       await expect(firstCard).toHaveClass(
-        "rounded-xl bg-white p-3 shadow-lg duration-100 hover:scale-105 hover:transform hover:shadow-xl"
+        "rounded-xl bg-white dark:bg-black p-3 shadow-lg dark:shadow-orange/20 duration-100 hover:scale-105 hover:transform hover:shadow-xl"
       );
     });
   });


### PR DESCRIPTION
## Summary
- Add `dark:bg-black` and `dark:shadow-orange/20` to Card component for proper dark mode display
- Add dark hover/color variants to Button component (primary and secondary styles)
- Add `dark:text-white` to Tags component for readability on dark backgrounds
- Update test assertion to include new dark mode classes

Fixes #184

## Test plan
- [x] All 55 Playwright tests pass
- [ ] Manually verify dark mode toggle shows cards with dark background
- [ ] Verify button hover states work correctly in both themes
- [ ] Verify tag text is readable in dark mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)