### PR TITLE
Update CV page meta tags to reflect current role

### DIFF
--- a/src/pages/cv.astro
+++ b/src/pages/cv.astro
@@ -6,8 +6,8 @@ import { Icon } from "astro-icon/components";
 ---
 
 <Layout
-  title="CV | Michalina Graczyk - Quality Assurance Lead"
-  description="CV i doświadczenie zawodowe. Head of QA z ponad 9-letnim doświadczeniem w testowaniu oprogramowania."
+  title="CV | Michalina Graczyk - Engineering Manager"
+  description="CV i doświadczenie zawodowe. Engineering Manager z ponad 10-letnim doświadczeniem w IT, specjalizująca się w QA, Test Automation i AI-driven Testing."
   type="website"
 >
   <main id="main-content" class="mb-20">


### PR DESCRIPTION
## Summary
- Update page title from "Quality Assurance Lead" to "Engineering Manager"
- Update meta description with current experience (10+ years) and expertise areas (QA, Test Automation, AI-driven Testing)

## Test plan
- [x] `npm run build` succeeds
- [ ] Verify meta tags appear correctly in page source

Closes #193
Closes #194

🤖 Generated with [Claude Code](https://claude.com/claude-code)