### PR TITLE
Add CI quality gates, caching, and Dependabot grouping

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,12 @@
 
 version: 2
 updates:
-  - package-ecosystem: "npm" # See documentation for possible values
-    directory: "/" # Location of package manifests
+  - package-ecosystem: "npm"
+    directory: "/"
     schedule:
       interval: "daily"
+    groups:
+      production:
+        dependency-type: "production"
+      development:
+        dependency-type: "development"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: Run Playwright Tests
+name: CI
 
 on: [push]
 
@@ -13,9 +13,19 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version-file: ".nvmrc"
+          cache: "npm"
 
       - name: Install dependencies
         run: npm ci
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Type check
+        run: npx astro check
+
+      - name: Build
+        run: npm run build
 
       - name: Install Playwright Browsers
         run: npx playwright install --with-deps

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,4 @@
+node_modules
+dist
+.astro
+playwright-report

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,6 +5,8 @@
 ```bash
 npm run dev          # Dev server at localhost:4321
 npm run build        # Production build
+npm run lint         # Check formatting
+npm run lint:fix     # Auto-fix formatting
 ```
 
 ## Testing

--- a/package.json
+++ b/package.json
@@ -8,6 +8,8 @@
     "build": "astro build",
     "preview": "astro preview",
     "astro": "astro",
+    "lint": "prettier --check .",
+    "lint:fix": "prettier --write .",
     "test:ci": "npx playwright test",
     "test:local": "BASE_URL=http://localhost:4321 npx playwright test"
   },

--- a/public/mixpanel.js
+++ b/public/mixpanel.js
@@ -25,7 +25,7 @@
       };
       i =
         "disable time_event track track_pageview track_links track_forms track_with_groups add_group set_group remove_group register register_once alias unregister identify name_tag set_config reset opt_in_tracking opt_out_tracking has_opted_in_tracking has_opted_out_tracking clear_opt_in_out_tracking start_batch_senders people.set people.set_once people.unset people.increment people.append people.union people.track_charge people.clear_charges people.delete_user people.remove".split(
-          " "
+          " ",
         );
       for (h = 0; h < i.length; h++) g(a, i[h]);
       var j = "set set_once union unset remove delete".split(" ");
@@ -57,9 +57,9 @@
       "undefined" !== typeof MIXPANEL_CUSTOM_LIB_URL
         ? MIXPANEL_CUSTOM_LIB_URL
         : "file:" === f.location.protocol &&
-          "//cdn.mxpnl.com/libs/mixpanel-2-latest.min.js".match(/^\/\//)
-        ? "https://cdn.mxpnl.com/libs/mixpanel-2-latest.min.js"
-        : "//cdn.mxpnl.com/libs/mixpanel-2-latest.min.js";
+            "//cdn.mxpnl.com/libs/mixpanel-2-latest.min.js".match(/^\/\//)
+          ? "https://cdn.mxpnl.com/libs/mixpanel-2-latest.min.js"
+          : "//cdn.mxpnl.com/libs/mixpanel-2-latest.min.js";
     g = f.getElementsByTagName("script")[0];
     g.parentNode.insertBefore(e, g);
   }
@@ -87,7 +87,7 @@
             console.log(
               "[Development] Mixpanel event tracked:",
               eventName,
-              eventProperties
+              eventProperties,
             );
           };
         }

--- a/src/lib/blog.ts
+++ b/src/lib/blog.ts
@@ -6,7 +6,7 @@ import { getCollection } from "astro:content";
  */
 export async function getPublishedPosts(): Promise<CollectionEntry<"blog">[]> {
   return getCollection("blog", ({ data }) =>
-    import.meta.env.PROD ? data.draft !== true : true
+    import.meta.env.PROD ? data.draft !== true : true,
   );
 }
 

--- a/tests/blog.spec.ts
+++ b/tests/blog.spec.ts
@@ -106,7 +106,9 @@ test.describe("Blog", () => {
       expect(failedImages).toHaveLength(0);
 
       // Verify content images are present and visible
-      const contentImages = page.locator('main article img[alt*="Cypress"], main article img[alt*="Playwright"]');
+      const contentImages = page.locator(
+        'main article img[alt*="Cypress"], main article img[alt*="Playwright"]',
+      );
       const imageCount = await contentImages.count();
       expect(imageCount).toBeGreaterThan(0);
 

--- a/tests/button-functionality.spec.ts
+++ b/tests/button-functionality.spec.ts
@@ -11,7 +11,7 @@ test.describe("Button Functionality", () => {
 
   test("Back-to-top button functionality", async ({ page }) => {
     const documentHeight = await page.evaluate(
-      () => document.documentElement.scrollHeight
+      () => document.documentElement.scrollHeight,
     );
     const viewportHeight = await page.evaluate(() => window.innerHeight);
 
@@ -21,7 +21,7 @@ test.describe("Button Functionality", () => {
 
     await page.waitForFunction(
       (height) => Math.abs(window.scrollY - height) <= 5,
-      documentHeight - viewportHeight
+      documentHeight - viewportHeight,
     );
 
     const backToTopButton = page.locator('[data-testid="back-to-top-button"]');
@@ -62,7 +62,7 @@ test.describe("Button Functionality", () => {
     const mixpanelEventsTracked = await getTrackedEvents(page);
     expectLastEventToBeTracked(
       mixpanelEventsTracked,
-      "Contact by mail button clicked"
+      "Contact by mail button clicked",
     );
   });
 
@@ -77,14 +77,14 @@ test.describe("Button Functionality", () => {
     const dataUrl = await calendlyPopup.getAttribute("data-url");
     expect(dataUrl).toEqual(
       expect.stringContaining(
-        "https://calendly.com/michalina_graczyk/konsultacje"
-      )
+        "https://calendly.com/michalina_graczyk/konsultacje",
+      ),
     );
 
     const mixpanelEventsTracked = await getTrackedEvents(page);
     expectLastEventToBeTracked(
       mixpanelEventsTracked,
-      "Contact by Calendly button clicked"
+      "Contact by Calendly button clicked",
     );
   });
 
@@ -98,7 +98,7 @@ test.describe("Button Functionality", () => {
     const mixpanelEventsTracked = await getTrackedEvents(page);
     expectLastEventToBeTracked(
       mixpanelEventsTracked,
-      "Learn more button clicked"
+      "Learn more button clicked",
     );
   });
 
@@ -119,7 +119,7 @@ test.describe("Button Functionality", () => {
       expectLastEventToBeTracked(
         mixpanelEventsTracked,
         "Social media button clicked",
-        { Name: name }
+        { Name: name },
       );
     }
   });

--- a/tests/content.spec.ts
+++ b/tests/content.spec.ts
@@ -10,14 +10,12 @@ test.describe("Page Content", () => {
     baseURL,
   }) => {
     await expect(page).toHaveURL(baseURL!);
-    await expect(page).toHaveTitle(
-      "Michalina Graczyk | Engineering Manager"
-    );
+    await expect(page).toHaveTitle("Michalina Graczyk | Engineering Manager");
 
     const descriptionMetaTag = page.locator("meta[name='description']");
     await expect(descriptionMetaTag).toHaveAttribute(
       "content",
-      "Michalina Graczyk - Engineering Manager w InPost | QA & Test Automation Strategy | AI-driven Testing | LLM Evaluation"
+      "Michalina Graczyk - Engineering Manager w InPost | QA & Test Automation Strategy | AI-driven Testing | LLM Evaluation",
     );
 
     const htmlElement = page.locator("html");
@@ -34,7 +32,7 @@ test.describe("Page Content", () => {
       const firstCard = page.locator('[data-testid="card"]').first();
       await firstCard.hover();
       await expect(firstCard).toHaveClass(
-        "rounded-xl bg-white dark:bg-gray-800 p-3 shadow-lg dark:shadow-orange/20 duration-100 hover:scale-105 hover:transform hover:shadow-xl"
+        "rounded-xl bg-white dark:bg-gray-800 p-3 shadow-lg dark:shadow-orange/20 duration-100 hover:scale-105 hover:transform hover:shadow-xl",
       );
     });
   });

--- a/tests/helpers/mixpanel.ts
+++ b/tests/helpers/mixpanel.ts
@@ -9,7 +9,7 @@ export async function getTrackedEvents(page: Page) {
 export function expectLastEventToBeTracked(
   events: typeof window.mixpanel.eventsTracked,
   eventName: string,
-  eventProperties?: Dict
+  eventProperties?: Dict,
 ) {
   const lastEvent = events[events.length - 1];
   expect(lastEvent).toEqual({ eventName, eventProperties });

--- a/tests/navigation.spec.ts
+++ b/tests/navigation.spec.ts
@@ -99,7 +99,7 @@ test.describe("Page Navigation", () => {
           expectLastEventToBeTracked(
             mixpanelEventsTracked,
             "Menu item clicked",
-            { Item: item.name }
+            { Item: item.name },
           );
         }
       }
@@ -118,7 +118,7 @@ test.describe("Page Navigation", () => {
           await navigationHeader.locator(`:text("${item.name}")`).click();
           const expectedUrlPattern = new RegExp(
             `${baseURL}${item.nav}/?$`,
-            "i"
+            "i",
           );
           await expect(page).toHaveURL(expectedUrlPattern);
         }

--- a/tests/offers.spec.ts
+++ b/tests/offers.spec.ts
@@ -18,17 +18,23 @@ test.describe("Offers", () => {
     }) => {
       await page.goto(`${baseURL}/#offers`);
 
-      const offerCards = page.locator('[data-testid="offers"] a[href^="/offers/"]');
+      const offerCards = page.locator(
+        '[data-testid="offers"] a[href^="/offers/"]',
+      );
       const count = await offerCards.count();
       expect(count).toBe(3);
 
       // Verify no Instagram links in offers section
-      const instagramLinks = page.locator('[data-testid="offers"] a[href*="instagram.com/stories"]');
+      const instagramLinks = page.locator(
+        '[data-testid="offers"] a[href*="instagram.com/stories"]',
+      );
       await expect(instagramLinks).toHaveCount(0);
 
       // Verify each card links to correct internal page
       for (const offer of offers) {
-        const card = page.locator(`[data-testid="offers"] a[href="/offers/${offer.slug}"]`);
+        const card = page.locator(
+          `[data-testid="offers"] a[href="/offers/${offer.slug}"]`,
+        );
         await expect(card).toBeVisible();
       }
     });
@@ -39,7 +45,9 @@ test.describe("Offers", () => {
     }) => {
       await page.goto(`${baseURL}/#offers`);
 
-      const firstCard = page.locator('[data-testid="offers"] a[href^="/offers/"]').first();
+      const firstCard = page
+        .locator('[data-testid="offers"] a[href^="/offers/"]')
+        .first();
       await firstCard.click();
 
       await expect(page).toHaveURL(/\/offers\/.+/);
@@ -48,7 +56,10 @@ test.describe("Offers", () => {
 
   test.describe("Offer Pages", () => {
     for (const offer of offers) {
-      test(`${offer.slug} page renders correctly`, async ({ page, baseURL }) => {
+      test(`${offer.slug} page renders correctly`, async ({
+        page,
+        baseURL,
+      }) => {
         await page.goto(`${baseURL}/offers/${offer.slug}`);
 
         // Verify page title
@@ -68,8 +79,12 @@ test.describe("Offers", () => {
 
         // Verify CTA section
         await expect(page.getByText("Zainteresowany/a?")).toBeVisible();
-        await expect(page.getByRole("button", { name: "Umów spotkanie" })).toBeVisible();
-        await expect(page.getByRole("link", { name: "Napisz maila" })).toBeVisible();
+        await expect(
+          page.getByRole("button", { name: "Umów spotkanie" }),
+        ).toBeVisible();
+        await expect(
+          page.getByRole("link", { name: "Napisz maila" }),
+        ).toBeVisible();
       });
     }
 
@@ -93,19 +108,25 @@ test.describe("Offers", () => {
     }) => {
       await page.goto(`${baseURL}/offers/konsultacje`);
 
-      const meetingButton = page.getByRole("button", { name: "Umów spotkanie" });
+      const meetingButton = page.getByRole("button", {
+        name: "Umów spotkanie",
+      });
       await meetingButton.click();
 
-      const calendlyPopup = await page.waitForSelector(".calendly-popup-content");
+      const calendlyPopup = await page.waitForSelector(
+        ".calendly-popup-content",
+      );
       expect(calendlyPopup).toBeTruthy();
 
       const dataUrl = await calendlyPopup.getAttribute("data-url");
-      expect(dataUrl).toContain("https://calendly.com/michalina_graczyk/konsultacje");
+      expect(dataUrl).toContain(
+        "https://calendly.com/michalina_graczyk/konsultacje",
+      );
 
       const mixpanelEventsTracked = await getTrackedEvents(page);
       expectLastEventToBeTracked(
         mixpanelEventsTracked,
-        "Offer booking clicked"
+        "Offer booking clicked",
       );
     });
 
@@ -122,10 +143,7 @@ test.describe("Offers", () => {
       await emailButton.click();
 
       const mixpanelEventsTracked = await getTrackedEvents(page);
-      expectLastEventToBeTracked(
-        mixpanelEventsTracked,
-        "Offer email clicked"
-      );
+      expectLastEventToBeTracked(mixpanelEventsTracked, "Offer email clicked");
     });
 
     test("JSON-LD structured data is present", async ({ page, baseURL }) => {


### PR DESCRIPTION
## Summary
- Add lint, type check, and build steps to CI workflow in fail-fast order
- Enable npm caching via `setup-node` action to speed up CI runs
- Configure Dependabot to group dependencies into production/development PRs

## Changes
- `.github/workflows/playwright-tests.yml` - Added quality gates + npm caching
- `.github/dependabot.yml` - Added dependency grouping
- `package.json` - Added `lint` script using Prettier
- `.prettierignore` - New file to exclude build artifacts
- 8 source files - Formatting fixes to pass lint

## Workflow Order
```
Checkout -> Setup Node (cached) -> Install -> Lint -> Type Check -> Build -> Playwright Browsers -> Tests
```

## Test plan
- [ ] Verify CI workflow runs all new steps in correct order
- [ ] Confirm npm caching works (check "Post Set up Node.js" step)
- [ ] Verify workflow fails fast on lint/type/build errors
- [ ] Check Dependabot creates grouped PRs on next dependency update

Closes #181

🤖 Generated with [Claude Code](https://claude.com/claude-code)