### PR TITLE
Add resource hints and lazy loading for performance

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -2,3 +2,4 @@ node_modules
 dist
 .astro
 playwright-report
+.claude

--- a/src/components/ui/Card.astro
+++ b/src/components/ui/Card.astro
@@ -49,7 +49,7 @@ const image = imageMap[title];
           alt={alt}
           layout="constrained"
           width={400}
-          priority
+          loading="lazy"
         />
       </div>
       <div class="mt-1 p-2">

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -77,13 +77,15 @@ const websiteSchema = {
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="generator" content={Astro.generator} />
     <link rel="icon" type="image/x-icon" href="/favicon.ico" />
+    <link rel="preconnect" href="https://assets.calendly.com" />
+    <link rel="preconnect" href="https://cdn.mxpnl.com" />
     <script type="application/ld+json" set:html={JSON.stringify(websiteSchema)} />
     <link
       href="https://assets.calendly.com/assets/external/widget.css"
       rel="stylesheet"
     />
 
-    <script src="/mixpanel.js" type="text/javascript"></script>
+    <script src="/mixpanel.js" type="text/javascript" defer></script>
     <script
       src="https://assets.calendly.com/assets/external/widget.js"
       type="text/javascript"


### PR DESCRIPTION
## Summary
- Add preconnect hints for Calendly (`assets.calendly.com`) and Mixpanel (`cdn.mxpnl.com`) CDNs to establish early connections
- Defer Mixpanel script loading to unblock initial render
- Change Card component images from eager (`priority`) to `loading="lazy"` for below-fold optimization

Closes #176

## Test plan
- [x] `npm run build` passes
- [x] All 165 Playwright tests pass
- [ ] Visual verification shows no regressions
- [ ] Network tab confirms preconnect fires early and Mixpanel is deferred
- [ ] Lighthouse Performance score does not regress

🤖 Generated with [Claude Code](https://claude.ai/code)