### PR TITLE
Add RSS feed and extract CV data to JSON

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@astrojs/mdx": "^4.3.13",
+        "@astrojs/rss": "^4.0.14",
         "@astrojs/sitemap": "^3.6.1",
         "@astrojs/tailwind": "^5.1.4",
         "@astrojs/ts-plugin": "^1.10.6",
@@ -230,6 +231,16 @@
       },
       "engines": {
         "node": "18.20.8 || ^20.3.0 || >=22.0.0"
+      }
+    },
+    "node_modules/@astrojs/rss": {
+      "version": "4.0.14",
+      "resolved": "https://registry.npmjs.org/@astrojs/rss/-/rss-4.0.14.tgz",
+      "integrity": "sha512-KCe1imDcADKOOuO/wtKOMDO/umsBD6DWF+94r5auna1jKl5fmlK9vzf+sjA3EyveXA/FoB3khtQ/u/tQgETmTw==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-xml-parser": "^5.3.0",
+        "piccolore": "^0.1.3"
       }
     },
     "node_modules/@astrojs/sitemap": {
@@ -3808,6 +3819,24 @@
       ],
       "license": "BSD-3-Clause"
     },
+    "node_modules/fast-xml-parser": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.3.3.tgz",
+      "integrity": "sha512-2O3dkPAAC6JavuMm8+4+pgTk+5hoAs+CjZ+sWcQLkX9+/tHRuTkQh/Oaifr8qDmZ8iEHb771Ea6G8CdwkrgvYA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "strnum": "^2.1.0"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      }
+    },
     "node_modules/fastq": {
       "version": "1.17.1",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.17.1.tgz",
@@ -7307,6 +7336,18 @@
       "funding": {
         "url": "https://github.com/chalk/strip-ansi?sponsor=1"
       }
+    },
+    "node_modules/strnum": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.1.2.tgz",
+      "integrity": "sha512-l63NF9y/cLROq/yqKXSLtcMeeyOfnSQlfMSlzFt/K73oIaD8DGaQWd7Z34X9GPiKqP5rbSh84Hl4bOlLcjiSrQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/style-to-js": {
       "version": "1.1.21",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   },
   "dependencies": {
     "@astrojs/mdx": "^4.3.13",
+    "@astrojs/rss": "^4.0.14",
     "@astrojs/sitemap": "^3.6.1",
     "@astrojs/tailwind": "^5.1.4",
     "@astrojs/ts-plugin": "^1.10.6",

--- a/src/data/cv.json
+++ b/src/data/cv.json
@@ -1,0 +1,127 @@
+{
+  "header": {
+    "name": "Michalina Graczyk",
+    "title": "Engineering Manager",
+    "links": [
+      {
+        "label": "LinkedIn",
+        "url": "https://www.linkedin.com/in/michalina-graczyk/",
+        "icon": "simple-icons:linkedin"
+      },
+      {
+        "label": "GitHub",
+        "url": "https://github.com/michalina-graczyk",
+        "icon": "simple-icons:github"
+      }
+    ]
+  },
+  "summary": "Engineering Manager z ponad 10-letnim doświadczeniem w IT. Specjalizuję się w QA & Test Automation Strategy, AI-driven Testing i LLM Evaluation. Pasjonatka efektywnej komunikacji i mentoringu, pomagająca innym w rozwoju kariery w IT.",
+  "experience": [
+    {
+      "title": "Engineering Manager",
+      "company": "InPost",
+      "dateRange": "lip 2025 - obecnie",
+      "responsibilities": [
+        "Tworzenie i wdrażanie strategii jakości (Master Test Strategy) dla zespołów produktowych (web, mobile, API)",
+        "Innowacyjne podejścia do testowania – strategia LLM-as-a-judge, Promptfoo, ocena odpowiedzi modeli AI",
+        "Współpraca z zespołami SRE i produktowymi w celu zapewnienia wysokiej jakości usług",
+        "Zarządzanie zespołem QA i rozwój kompetencji w obszarze automatyzacji oraz AI-driven testing"
+      ]
+    },
+    {
+      "title": "Head of Quality Assurance",
+      "company": "Saleor Commerce",
+      "dateRange": "lut 2022 - maj 2025 • 3 lata 4 mies.",
+      "responsibilities": [
+        "Zarządzanie zespołem: rozwój umiejętności zespołu, mentoring i organizacja pracy",
+        "Koordynacja QA Guild: rozwój wewnętrznych praktyk i promowanie kultury jakości",
+        "Projektowanie i optymalizacja procesów zapewniania jakości",
+        "Nadzór nad procesami testowania manualnego i automatycznego",
+        "Zarządzanie procesem rekrutacji w zespole QA"
+      ]
+    },
+    {
+      "title": "Urlop rodzicielski",
+      "company": null,
+      "dateRange": "2021",
+      "responsibilities": null
+    },
+    {
+      "title": "Quality Assurance Specialist",
+      "company": "Saleor Commerce",
+      "dateRange": "mar 2020 - gru 2020 • 10 mies.",
+      "responsibilities": [
+        "Pierwsza osoba w firmie na stanowisku QA",
+        "Wprowadzenie i implementacja testów automatycznych",
+        "Rozwój strategii i procesów testowych",
+        "Budowanie kultury jakości w organizacji"
+      ]
+    },
+    {
+      "title": "QA Engineer",
+      "company": "Kellton Europe (Tivix)",
+      "dateRange": "lis 2018 - lut 2020 • 1 rok 4 mies.",
+      "responsibilities": null
+    },
+    {
+      "title": "Quality Control Engineer",
+      "company": "SoftServe",
+      "dateRange": "maj 2018 - lis 2018 • 7 mies.",
+      "responsibilities": null
+    },
+    {
+      "title": "QA Engineer",
+      "company": "Shiji Group",
+      "dateRange": "wrz 2016 - kwi 2018 • 1 rok 8 mies.",
+      "responsibilities": null
+    },
+    {
+      "title": "QA Engineer",
+      "company": "EUVIC",
+      "dateRange": "lut 2015 - kwi 2018 • 3 lata 3 mies.",
+      "responsibilities": null
+    }
+  ],
+  "education": [
+    {
+      "institution": "Akademia WSB",
+      "degree": "Magister Informatyki",
+      "dateRange": "2016 - 2018"
+    },
+    {
+      "institution": "Politechnika Śląska",
+      "degree": "Inżynier Zarządzania i Inżynierii Produkcji",
+      "dateRange": "2012 - 2016"
+    }
+  ],
+  "certifications": [
+    {
+      "name": "Human Leader in Feedback with Impact",
+      "issuer": "Human Leaders",
+      "date": "wrz 2025",
+      "credentialId": null
+    },
+    {
+      "name": "Introduction to Observability",
+      "issuer": "Datadog",
+      "date": "cze 2024",
+      "credentialId": "eukfvuvi0u"
+    },
+    {
+      "name": "ISTQB Foundation Level",
+      "issuer": "Polish Testing Board",
+      "date": "paź 2016",
+      "credentialId": "06281/FLCT/2016"
+    }
+  ],
+  "publications": [
+    {
+      "title": "Shift Left Done Right: QA in the Modern SDLC",
+      "date": "kwi 2025"
+    },
+    {
+      "title": "From Cypress to Playwright - Saleor's Voyage",
+      "date": "lis 2024"
+    }
+  ]
+}

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -84,6 +84,12 @@ const websiteSchema = {
     <meta name="generator" content={Astro.generator} />
     <meta name="keywords" content="QA, Engineering Manager, LLM Evaluation, AI Testing, Mobile QA" />
     <link rel="icon" type="image/x-icon" href="/favicon.ico" />
+    <link
+      rel="alternate"
+      type="application/rss+xml"
+      title="Michalina Graczyk - Blog"
+      href="/rss.xml"
+    />
     <link rel="preconnect" href="https://assets.calendly.com" />
     <link rel="preconnect" href="https://cdn.mxpnl.com" />
     <script type="application/ld+json" set:html={JSON.stringify(websiteSchema)} />

--- a/src/pages/cv.astro
+++ b/src/pages/cv.astro
@@ -3,6 +3,7 @@ import BackToTop from "@components/ui/BackToTop.astro";
 import Layout from "@layouts/Layout.astro";
 import SectionTitle from "@components/ui/SectionTitle.astro";
 import { Icon } from "astro-icon/components";
+import cvData from "@data/cv.json";
 ---
 
 <Layout
@@ -15,30 +16,25 @@ import { Icon } from "astro-icon/components";
       <!-- Header -->
       <header class="mb-10 text-center">
         <h1 class="mb-2 font-monospace text-4xl text-orange">
-          Michalina Graczyk
+          {cvData.header.name}
         </h1>
         <p class="text-lg font-bold text-black dark:text-white">
-          Engineering Manager
+          {cvData.header.title}
         </p>
         <div class="flex justify-center gap-4">
-          <a
-            href="https://www.linkedin.com/in/michalina-graczyk/"
-            target="_blank"
-            rel="noopener"
-            class="mt-2 inline-flex items-center text-black hover:text-orange dark:text-white dark:hover:text-orange"
-          >
-            <Icon class="h-5 w-5 mr-1" name="simple-icons:linkedin" />
-            <p>LinkedIn</p>
-          </a>
-          <a
-            href="https://github.com/michalina-graczyk"
-            target="_blank"
-            rel="noopener"
-            class="mt-2 inline-flex items-center text-black hover:text-orange dark:text-white dark:hover:text-orange"
-          >
-            <Icon class="h-5 w-5 mr-1" name="simple-icons:github" />
-            <p>GitHub</p>
-          </a>
+          {
+            cvData.header.links.map((link) => (
+              <a
+                href={link.url}
+                target="_blank"
+                rel="noopener"
+                class="mt-2 inline-flex items-center text-black hover:text-orange dark:text-white dark:hover:text-orange"
+              >
+                <Icon class="h-5 w-5 mr-1" name={link.icon} />
+                <p>{link.label}</p>
+              </a>
+            ))
+          }
         </div>
       </header>
 
@@ -46,10 +42,7 @@ import { Icon } from "astro-icon/components";
       <section class="mb-12">
         <SectionTitle>O mnie</SectionTitle>
         <p class="text-black dark:text-white">
-          Engineering Manager z ponad 10-letnim doświadczeniem w IT. Specjalizuję
-          się w QA & Test Automation Strategy, AI-driven Testing i LLM Evaluation.
-          Pasjonatka efektywnej komunikacji i mentoringu, pomagająca innym w
-          rozwoju kariery w IT.
+          {cvData.summary}
         </p>
       </section>
 
@@ -57,83 +50,24 @@ import { Icon } from "astro-icon/components";
       <section class="mb-12">
         <SectionTitle>Doświadczenie</SectionTitle>
         <div class="space-y-8 text-black dark:text-white">
-          <div>
-            <h3 class="text-xl font-bold">Engineering Manager</h3>
-            <p class="text-orange">InPost • lip 2025 - obecnie</p>
-            <ul class="mt-2 list-disc pl-5 space-y-1">
-              <li>
-                Tworzenie i wdrażanie strategii jakości (Master Test Strategy)
-                dla zespołów produktowych (web, mobile, API)
-              </li>
-              <li>
-                Innowacyjne podejścia do testowania – strategia LLM-as-a-judge,
-                Promptfoo, ocena odpowiedzi modeli AI
-              </li>
-              <li>
-                Współpraca z zespołami SRE i produktowymi w celu zapewnienia
-                wysokiej jakości usług
-              </li>
-              <li>
-                Zarządzanie zespołem QA i rozwój kompetencji w obszarze
-                automatyzacji oraz AI-driven testing
-              </li>
-            </ul>
-          </div>
-          <div>
-            <h3 class="text-xl font-bold">Head of Quality Assurance</h3>
-            <p class="text-orange">Saleor Commerce • lut 2022 - maj 2025 • 3 lata 4 mies.</p>
-            <ul class="mt-2 list-disc pl-5 space-y-1">
-              <li>
-                Zarządzanie zespołem: rozwój umiejętności zespołu, mentoring i
-                organizacja pracy
-              </li>
-              <li>
-                Koordynacja QA Guild: rozwój wewnętrznych praktyk i promowanie
-                kultury jakości
-              </li>
-              <li>
-                Projektowanie i optymalizacja procesów zapewniania jakości
-              </li>
-              <li>
-                Nadzór nad procesami testowania manualnego i automatycznego
-              </li>
-              <li>Zarządzanie procesem rekrutacji w zespole QA</li>
-            </ul>
-          </div>
-          <div>
-            <h3 class="text-xl font-bold">Urlop rodzicielski</h3>
-            <p class="text-orange">2021</p>
-          </div>
-          <div>
-            <h3 class="text-xl font-bold">Quality Assurance Specialist</h3>
-            <p class="text-orange">Saleor Commerce • mar 2020 - gru 2020 • 10 mies.</p>
-            <ul class="mt-2 list-disc pl-5 space-y-1">
-              <li>Pierwsza osoba w firmie na stanowisku QA</li>
-              <li>Wprowadzenie i implementacja testów automatycznych</li>
-              <li>Rozwój strategii i procesów testowych</li>
-              <li>Budowanie kultury jakości w organizacji</li>
-            </ul>
-          </div>
-
-          <div>
-            <h3 class="text-xl font-bold">QA Engineer</h3>
-            <p class="text-orange">Kellton Europe (Tivix) • lis 2018 - lut 2020 • 1 rok 4 mies.</p>
-          </div>
-
-          <div>
-            <h3 class="text-xl font-bold">Quality Control Engineer</h3>
-            <p class="text-orange">SoftServe • maj 2018 - lis 2018 • 7 mies.</p>
-          </div>
-
-          <div>
-            <h3 class="text-xl font-bold">QA Engineer</h3>
-            <p class="text-orange">Shiji Group • wrz 2016 - kwi 2018 • 1 rok 8 mies.</p>
-          </div>
-
-          <div>
-            <h3 class="text-xl font-bold">QA Engineer</h3>
-            <p class="text-orange">EUVIC • lut 2015 - kwi 2018 • 3 lata 3 mies.</p>
-          </div>
+          {
+            cvData.experience.map((job) => (
+              <div>
+                <h3 class="text-xl font-bold">{job.title}</h3>
+                <p class="text-orange">
+                  {job.company ? `${job.company} • ` : ""}
+                  {job.dateRange}
+                </p>
+                {job.responsibilities && (
+                  <ul class="mt-2 list-disc pl-5 space-y-1">
+                    {job.responsibilities.map((item) => (
+                      <li>{item}</li>
+                    ))}
+                  </ul>
+                )}
+              </div>
+            ))
+          }
         </div>
       </section>
 
@@ -141,17 +75,16 @@ import { Icon } from "astro-icon/components";
       <section class="mb-12">
         <SectionTitle>Edukacja</SectionTitle>
         <div class="space-y-4 text-black dark:text-white">
-          <div>
-            <h3 class="text-xl font-bold">Akademia WSB</h3>
-            <p class="text-orange">Magister Informatyki • 2016 - 2018</p>
-          </div>
-
-          <div>
-            <h3 class="text-xl font-bold">Politechnika Śląska</h3>
-            <p class="text-orange">
-              Inżynier Zarządzania i Inżynierii Produkcji • 2012 - 2016
-            </p>
-          </div>
+          {
+            cvData.education.map((edu) => (
+              <div>
+                <h3 class="text-xl font-bold">{edu.institution}</h3>
+                <p class="text-orange">
+                  {edu.degree} • {edu.dateRange}
+                </p>
+              </div>
+            ))
+          }
         </div>
       </section>
 
@@ -159,22 +92,17 @@ import { Icon } from "astro-icon/components";
       <section class="mb-12">
         <SectionTitle>Certyfikaty</SectionTitle>
         <div class="space-y-4 text-black dark:text-white">
-          <div>
-            <h3 class="text-xl font-bold">Human Leader in Feedback with Impact</h3>
-            <p class="text-orange">Human Leaders • wrz 2025</p>
-          </div>
-
-          <div>
-            <h3 class="text-xl font-bold">Introduction to Observability</h3>
-            <p class="text-orange">Datadog • cze 2024</p>
-            <p class="text-sm">ID: eukfvuvi0u</p>
-          </div>
-
-          <div>
-            <h3 class="text-xl font-bold">ISTQB Foundation Level</h3>
-            <p class="text-orange">Polish Testing Board • paź 2016</p>
-            <p class="text-sm">ID: 06281/FLCT/2016</p>
-          </div>
+          {
+            cvData.certifications.map((cert) => (
+              <div>
+                <h3 class="text-xl font-bold">{cert.name}</h3>
+                <p class="text-orange">
+                  {cert.issuer} • {cert.date}
+                </p>
+                {cert.credentialId && <p class="text-sm">ID: {cert.credentialId}</p>}
+              </div>
+            ))
+          }
         </div>
       </section>
 
@@ -182,15 +110,14 @@ import { Icon } from "astro-icon/components";
       <section class="mb-12">
         <SectionTitle>Publikacje</SectionTitle>
         <div class="space-y-4 text-black dark:text-white">
-          <div>
-            <h3 class="text-xl font-bold">Shift Left Done Right: QA in the Modern SDLC</h3>
-            <p class="text-orange">kwi 2025</p>
-          </div>
-
-          <div>
-            <h3 class="text-xl font-bold">From Cypress to Playwright - Saleor's Voyage</h3>
-            <p class="text-orange">lis 2024</p>
-          </div>
+          {
+            cvData.publications.map((pub) => (
+              <div>
+                <h3 class="text-xl font-bold">{pub.title}</h3>
+                <p class="text-orange">{pub.date}</p>
+              </div>
+            ))
+          }
         </div>
       </section>
     </div>

--- a/src/pages/rss.xml.ts
+++ b/src/pages/rss.xml.ts
@@ -1,0 +1,24 @@
+import rss from "@astrojs/rss";
+import type { APIContext } from "astro";
+import { getPublishedPosts } from "@lib/blog";
+
+export async function GET(context: APIContext) {
+  const posts = await getPublishedPosts();
+
+  const sortedPosts = posts.sort(
+    (a, b) => b.data.date.getTime() - a.data.date.getTime(),
+  );
+
+  return rss({
+    title: "Michalina Graczyk - Blog",
+    description:
+      "Artykuły o LLM Evaluation, AI Testing, Mobile QA i quality engineering. Praktyczne porady i przemyślenia lidera QA.",
+    site: context.site!,
+    items: sortedPosts.map((post) => ({
+      title: post.data.title,
+      pubDate: post.data.date,
+      description: post.data.excerpt,
+      link: `/blog/${post.slug}/`,
+    })),
+  });
+}

--- a/tests/cv.spec.ts
+++ b/tests/cv.spec.ts
@@ -1,0 +1,84 @@
+import { expect, test } from "@playwright/test";
+
+test.describe("CV Page", () => {
+  test.beforeEach(async ({ page, baseURL }) => {
+    await page.goto(`${baseURL}/cv`);
+  });
+
+  test("CV page renders with correct SEO metadata", async ({ page }) => {
+    await expect(page).toHaveTitle(
+      "CV | Michalina Graczyk - Engineering Manager",
+    );
+
+    const descriptionMetaTag = page.locator("meta[name='description']");
+    await expect(descriptionMetaTag).toHaveAttribute(
+      "content",
+      "CV i doświadczenie zawodowe. Engineering Manager z ponad 10-letnim doświadczeniem w IT, specjalizująca się w QA, Test Automation i AI-driven Testing.",
+    );
+  });
+
+  test("CV header displays name and title from data", async ({ page }) => {
+    const main = page.locator("#main-content");
+    const name = main.locator("header h1");
+    await expect(name).toHaveText("Michalina Graczyk");
+
+    const title = main.locator("header p").first();
+    await expect(title).toHaveText("Engineering Manager");
+  });
+
+  test("CV social links are present in header", async ({ page }) => {
+    const main = page.locator("#main-content");
+    const header = main.locator("header");
+
+    const linkedInLink = header.getByRole("link", { name: "LinkedIn" });
+    await expect(linkedInLink).toBeVisible();
+    await expect(linkedInLink).toHaveAttribute(
+      "href",
+      "https://www.linkedin.com/in/michalina-graczyk/",
+    );
+
+    const githubLink = header.getByRole("link", { name: "GitHub" });
+    await expect(githubLink).toBeVisible();
+    await expect(githubLink).toHaveAttribute(
+      "href",
+      "https://github.com/michalina-graczyk",
+    );
+  });
+
+  test("CV sections are rendered from data", async ({ page }) => {
+    // Verify all sections are present
+    const sections = [
+      "O mnie",
+      "Doświadczenie",
+      "Edukacja",
+      "Certyfikaty",
+      "Publikacje",
+    ];
+
+    for (const section of sections) {
+      await expect(page.getByRole("heading", { name: section })).toBeVisible();
+    }
+  });
+
+  test("CV experience entries are rendered", async ({ page }) => {
+    // Check that experience entries from JSON are displayed
+    const experienceItems = [
+      "Engineering Manager",
+      "Head of Quality Assurance",
+      "Quality Assurance Specialist",
+    ];
+
+    for (const item of experienceItems) {
+      await expect(page.getByRole("heading", { name: item })).toBeVisible();
+    }
+  });
+
+  test("CV certifications with credential IDs are displayed", async ({
+    page,
+  }) => {
+    // ISTQB has a credential ID
+    await expect(page.getByText("ID: 06281/FLCT/2016")).toBeVisible();
+    // Datadog has a credential ID
+    await expect(page.getByText("ID: eukfvuvi0u")).toBeVisible();
+  });
+});

--- a/tests/rss.spec.ts
+++ b/tests/rss.spec.ts
@@ -1,0 +1,53 @@
+import { expect, test } from "@playwright/test";
+
+test.describe("RSS Feed", () => {
+  test("RSS endpoint returns valid XML with required elements", async ({
+    request,
+    baseURL,
+  }) => {
+    const response = await request.get(`${baseURL}/rss.xml`);
+    expect(response.ok()).toBeTruthy();
+    expect(response.headers()["content-type"]).toContain("application/xml");
+
+    const body = await response.text();
+
+    // Check RSS 2.0 structure
+    expect(body).toContain('<?xml version="1.0" encoding="UTF-8"?>');
+    expect(body).toContain("<rss");
+    expect(body).toContain("<channel>");
+
+    // Check required channel elements
+    expect(body).toContain("<title>Michalina Graczyk - Blog</title>");
+    expect(body).toContain("<link>https://michalinqa.dev/</link>");
+    expect(body).toContain("<description>");
+
+    // Check that items have required elements
+    expect(body).toContain("<item>");
+    expect(body).toContain("<pubDate>");
+  });
+
+  test("RSS autodiscovery link is present in page head", async ({
+    page,
+    baseURL,
+  }) => {
+    await page.goto(baseURL!);
+
+    const rssLink = page.locator('link[type="application/rss+xml"]');
+    await expect(rssLink).toHaveAttribute("rel", "alternate");
+    await expect(rssLink).toHaveAttribute("href", "/rss.xml");
+    await expect(rssLink).toHaveAttribute("title", "Michalina Graczyk - Blog");
+  });
+
+  test("RSS autodiscovery link is present on all pages", async ({
+    page,
+    baseURL,
+  }) => {
+    const pages = ["/", "/blog", "/cv"];
+
+    for (const pagePath of pages) {
+      await page.goto(`${baseURL}${pagePath}`);
+      const rssLink = page.locator('link[type="application/rss+xml"]');
+      await expect(rssLink).toHaveAttribute("href", "/rss.xml");
+    }
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,7 +19,8 @@
       "@assets/*": ["assets/*"],
       "@pages/*": ["pages/*"],
       "@lib/*": ["lib/*"],
-      "@config/*": ["config/*"]
+      "@config/*": ["config/*"],
+      "@data/*": ["data/*"]
     }
   }
 }


### PR DESCRIPTION
## Summary
- Add RSS feed endpoint at `/rss.xml` with autodiscovery link in page head
- Extract CV data to `src/data/cv.json` for maintainable data-driven rendering
- Refactor `cv.astro` to consume JSON data while preserving visual design

Closes #182

## Changes
| Component | What Changed |
|-----------|--------------|
| RSS Feed | Installed `@astrojs/rss`, created `/rss.xml` endpoint, added autodiscovery link |
| CV Data | Created `src/data/cv.json`, refactored `cv.astro` to use data |
| Config | Added `@data/*` path alias to tsconfig.json |
| Tests | Added 9 new tests for RSS and CV functionality |

## Test plan
- [x] Build passes (`npm run build`)
- [x] Lint passes (`npm run lint`)
- [x] All 220 tests pass (`npm run test:local`)
- [x] `/rss.xml` returns valid RSS 2.0 XML
- [x] `/cv` renders correctly from JSON data
- [x] RSS autodiscovery link present in page head

🤖 Generated with [Claude Code](https://claude.ai/code)