### PR TITLE
Simplify Contact section with LinkedIn as primary CTA (#198)

### DIFF
--- a/src/components/Contact.astro
+++ b/src/components/Contact.astro
@@ -2,9 +2,11 @@
 import Button from "@components/ui/Button.astro";
 import Social from "@components/ui/Social.astro";
 import SectionTitle from "@components/ui/SectionTitle.astro";
-import { calendlyURL, emailAddress } from "@config/contact";
+import { emailAddress } from "@config/contact";
 
-const onMeetingClick = `Calendly.initPopupWidget({url: '${calendlyURL}'}); window.mixpanel.track('Contact by Calendly button clicked'); return false;`;
+const linkedinURL = "https://www.linkedin.com/in/michalina-graczyk/";
+const onLinkedInClick =
+  "window.mixpanel.track('Contact by LinkedIn button clicked');";
 const onEmailClick = "window.mixpanel.track('Contact by mail button clicked');";
 
 const socials = [
@@ -35,6 +37,17 @@ const socials = [
   <div class="flex gap-4">
     <Button
       size={"lg"}
+      style={"primary"}
+      name="LinkedIn"
+      href={linkedinURL}
+      target="_blank"
+      rel="noopener noreferrer"
+      onclick={onLinkedInClick}
+    >
+      Połączmy się
+    </Button>
+    <Button
+      size={"lg"}
       style={"secondary"}
       name="E-mail"
       href={emailAddress}
@@ -42,12 +55,6 @@ const socials = [
     >
       Napisz maila
     </Button>
-    <Button
-      size={"lg"}
-      style={"primary"}
-      name="Meeting"
-      onclick={onMeetingClick}>Umów spotkanie</Button
-    >
   </div>
   <hr class="w-1/2" />
   <Social socials={socials} />

--- a/tests/button-functionality.spec.ts
+++ b/tests/button-functionality.spec.ts
@@ -66,25 +66,23 @@ test.describe("Button Functionality", () => {
     );
   });
 
-  test("Meeting button functionality", async ({ page }) => {
-    const buttonLocator = "text=Umów spotkanie";
+  test("LinkedIn button functionality", async ({ page }) => {
+    const buttonLocator = "text=Połączmy się";
+    const href = await page.getAttribute(buttonLocator, "href");
+    expect(href).toBe("https://www.linkedin.com/in/michalina-graczyk/");
+
+    const target = await page.getAttribute(buttonLocator, "target");
+    expect(target).toBe("_blank");
+
+    const rel = await page.getAttribute(buttonLocator, "rel");
+    expect(rel).toBe("noopener noreferrer");
 
     await page.click(buttonLocator);
-
-    const calendlyPopup = await page.waitForSelector(".calendly-popup-content");
-    expect(calendlyPopup).toBeTruthy();
-
-    const dataUrl = await calendlyPopup.getAttribute("data-url");
-    expect(dataUrl).toEqual(
-      expect.stringContaining(
-        "https://calendly.com/michalina_graczyk/konsultacje",
-      ),
-    );
 
     const mixpanelEventsTracked = await getTrackedEvents(page);
     expectLastEventToBeTracked(
       mixpanelEventsTracked,
-      "Contact by Calendly button clicked",
+      "Contact by LinkedIn button clicked",
     );
   });
 


### PR DESCRIPTION
## Summary
- Replace broken Calendly integration with LinkedIn "Połączmy się" button as primary CTA
- Email button remains as secondary contact option
- Update test coverage for new LinkedIn button functionality

Closes #198
Closes #183

## Test plan
- [x] LinkedIn button visible with primary styling (orange)
- [x] LinkedIn button opens in new tab with `target="_blank"` and `rel="noopener noreferrer"`
- [x] Email button remains functional as secondary option
- [x] Mixpanel tracking fires for LinkedIn button clicks
- [x] All 220 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)