### PR TITLE
feat: LatestPosts homepage section (#370)

### DIFF
--- a/src/components/LatestPosts.astro
+++ b/src/components/LatestPosts.astro
@@ -5,14 +5,14 @@ import { getPublishedPosts, getLanguageFlag } from "@lib/blog";
 
 const posts = await getPublishedPosts();
 
+// .toSorted() avoids mutating the array returned by getCollection (shared cache).
 const latestPosts = posts
-  .sort((a, b) => b.data.date.getTime() - a.data.date.getTime())
+  .toSorted((a, b) => b.data.date.getTime() - a.data.date.getTime())
   .slice(0, 3);
 ---
 
 <section
   data-testid="latest-posts"
-  aria-label="Z bloga"
   class="mx-auto w-full max-w-3xl px-4 py-16 lg:py-24"
 >
   <SectionTitle>

--- a/src/components/LatestPosts.astro
+++ b/src/components/LatestPosts.astro
@@ -1,0 +1,148 @@
+---
+import SectionTitle from "@components/ui/SectionTitle.astro";
+import { Icon } from "astro-icon/components";
+import { getPublishedPosts, getLanguageFlag } from "@lib/blog";
+
+const posts = await getPublishedPosts();
+
+const latestPosts = posts
+  .sort((a, b) => b.data.date.getTime() - a.data.date.getTime())
+  .slice(0, 3);
+---
+
+<section
+  data-testid="latest-posts"
+  aria-label="Z bloga"
+  class="mx-auto w-full max-w-3xl px-4 py-16 lg:py-24"
+>
+  <SectionTitle>
+    Z bloga
+    <Fragment slot="subtitle">
+      Najnowsze wpisy o jakości, testach i LLM-ach
+    </Fragment>
+  </SectionTitle>
+
+  {
+    latestPosts.length === 0 ? (
+      <div class="mt-8 text-center">
+        <div class="mb-4 inline-flex h-16 w-16 items-center justify-center rounded-full bg-orange/10">
+          <Icon name="mdi:pencil-outline" class="h-8 w-8 text-orange" />
+        </div>
+        <p class="text-lg text-gray-600 dark:text-gray-400">
+          Wkrótce pojawią się nowe artykuły. Zapraszam wkrótce!
+        </p>
+      </div>
+    ) : (
+      <ul class="mt-4 divide-y divide-black/10 dark:divide-white/10">
+        {latestPosts.map((post, index) => {
+          const formattedDate = post.data.date.toLocaleDateString("pl-PL", {
+            day: "2-digit",
+            month: "2-digit",
+            year: "numeric",
+          });
+          const isoDate = post.data.date.toISOString();
+          const langLabel =
+            post.data.lang === "pl" ? "Wpis po polsku" : "Post in English";
+          const tags = (post.data.tags ?? []).slice(0, 3);
+
+          return (
+            <li>
+              <article class="py-6 lg:py-8">
+                <div class="mb-2 flex items-center gap-3 text-sm text-gray-500 dark:text-gray-400">
+                  <time datetime={isoDate}>{formattedDate}</time>
+                  <span class="inline-flex items-center text-base leading-none">
+                    <span aria-hidden="true">
+                      {getLanguageFlag(post.data.lang)}
+                    </span>
+                    <span class="sr-only">{langLabel}</span>
+                  </span>
+                </div>
+
+                <h3 class="mb-2 text-xl font-bold text-black dark:text-white lg:text-2xl">
+                  <a
+                    href={`/blog/${post.id}`}
+                    data-blog-teaser-link
+                    data-slug={post.id}
+                    data-position={index}
+                    class="latest-post-title-link bg-no-repeat focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-orange focus-visible:ring-offset-2"
+                  >
+                    {post.data.title}
+                  </a>
+                </h3>
+
+                <p class="mb-3 line-clamp-1 text-gray-600 dark:text-gray-400 lg:line-clamp-2">
+                  {post.data.excerpt}
+                </p>
+
+                {tags.length > 0 && (
+                  <div class="flex flex-wrap gap-2">
+                    {tags.map((tag) => (
+                      <span class="rounded-full border border-orange/30 bg-orange/10 px-2.5 py-0.5 text-xs font-medium text-orange">
+                        {tag}
+                      </span>
+                    ))}
+                  </div>
+                )}
+              </article>
+            </li>
+          );
+        })}
+      </ul>
+
+      <div class="mt-6 flex justify-end">
+        <a
+          href="/blog"
+          data-blog-teaser-view-all
+          class="latest-posts-view-all group inline-flex items-center gap-1 text-sm font-medium text-orange focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-orange focus-visible:ring-offset-2"
+        >
+          Wszystkie wpisy
+          <Icon
+            name="mdi:arrow-right"
+            class="h-4 w-4 transition-transform duration-150 ease-out group-hover:translate-x-1 motion-reduce:transition-none motion-reduce:group-hover:translate-x-0"
+          />
+        </a>
+      </div>
+    )
+  }
+</section>
+
+<style>
+  .latest-post-title-link {
+    background-image: linear-gradient(currentColor, currentColor);
+    background-position: 0 100%;
+    background-size: 0 1px;
+    transition:
+      background-size 200ms ease-out,
+      color 200ms ease-out;
+  }
+
+  .latest-post-title-link:hover,
+  .latest-post-title-link:focus-visible {
+    color: var(--color-orange);
+    background-size: 100% 1px;
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .latest-post-title-link {
+      transition: none;
+    }
+  }
+</style>
+
+<script>
+  import { trackClick, TrackingEvents } from "@lib/tracking";
+
+  trackClick(
+    "[data-blog-teaser-link]",
+    TrackingEvents.BLOG_TEASER_CLICKED,
+    (el) => ({
+      slug: el.getAttribute("data-slug") ?? "",
+      position: Number(el.getAttribute("data-position") ?? 0),
+    }),
+  );
+
+  trackClick(
+    "[data-blog-teaser-view-all]",
+    TrackingEvents.BLOG_TEASER_VIEW_ALL_CLICKED,
+  );
+</script>

--- a/src/components/ui/SectionTitle.astro
+++ b/src/components/ui/SectionTitle.astro
@@ -1,6 +1,18 @@
+---
+const hasSubtitle = Astro.slots.has("subtitle");
+---
+
 <div class="flex flex-col flex-wrap items-center justify-center">
   <h2 class="font-monospace text-2xl text-orange lg:text-4xl">
     <slot />
   </h2>
-  <span class="mb-6 ml-2 h-1 w-10 bg-orange"></span>
+  <span class:list={["ml-2 h-1 w-10 bg-orange", hasSubtitle ? "mb-3" : "mb-6"]}
+  ></span>
+  {
+    hasSubtitle && (
+      <p class="mb-6 max-w-xl px-4 text-center text-sm text-gray-600 dark:text-gray-400">
+        <slot name="subtitle" />
+      </p>
+    )
+  }
 </div>

--- a/src/lib/tracking.ts
+++ b/src/lib/tracking.ts
@@ -20,6 +20,8 @@ export const TrackingEvents = {
   OFFER_BOOKING_CLICKED: "Offer Booking Clicked",
   OFFER_WAITLIST_CLICKED: "Offer Waitlist Clicked",
   NEWSLETTER_SIGNUP_CLICKED: "Newsletter Signup Clicked",
+  BLOG_TEASER_CLICKED: "Blog Teaser Clicked",
+  BLOG_TEASER_VIEW_ALL_CLICKED: "Blog Teaser View All Clicked",
 } as const;
 
 export type EventName = (typeof TrackingEvents)[keyof typeof TrackingEvents];

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -2,6 +2,7 @@
 import About from "@components/About.astro";
 import Contact from "@components/Contact.astro";
 import Hero from "@components/Hero.astro";
+import LatestPosts from "@components/LatestPosts.astro";
 import Media from "@components/Media.astro";
 import Offers from "@components/Offers.astro";
 import Testimonials from "@components/Testimonials.astro";
@@ -25,6 +26,7 @@ const personSchema = {
   <script type="application/ld+json" set:html={JSON.stringify(personSchema)} />
   <main id="main-content">
     <Hero />
+    <LatestPosts />
     <About />
     <Offers />
     <Testimonials />

--- a/tests/latest-posts.spec.ts
+++ b/tests/latest-posts.spec.ts
@@ -1,5 +1,10 @@
 import { expect, test } from "@playwright/test";
-import { acceptConsentIfVisible } from "./helpers/mixpanel";
+import {
+  acceptConsentIfVisible,
+  expectLastEventToBeTracked,
+  getTrackedEvents,
+  TrackingEvents,
+} from "./helpers/mixpanel";
 
 test.describe("Homepage LatestPosts section", () => {
   test.beforeEach(async ({ page, baseURL }) => {
@@ -7,12 +12,28 @@ test.describe("Homepage LatestPosts section", () => {
     await acceptConsentIfVisible(page);
   });
 
-  test("renders between Hero and About", async ({ page }) => {
+  test("renders in DOM order: Hero → LatestPosts → About", async ({ page }) => {
     const section = page.locator('[data-testid="latest-posts"]');
     await expect(section).toBeVisible();
     await expect(
       section.getByRole("heading", { name: "Z bloga" }),
     ).toBeVisible();
+
+    const order = await page.evaluate(() => {
+      const ids = ["hero", "latest-posts", "about"];
+      const tops = ids.map((id) => {
+        const el =
+          document.querySelector(`[data-testid="${id}"]`) ??
+          document.getElementById(id);
+        return el ? el.getBoundingClientRect().top + window.scrollY : null;
+      });
+      return tops;
+    });
+    expect(order[0]).not.toBeNull();
+    expect(order[1]).not.toBeNull();
+    expect(order[2]).not.toBeNull();
+    expect(order[0]!).toBeLessThan(order[1]!);
+    expect(order[1]!).toBeLessThan(order[2]!);
   });
 
   test("shows at most 3 posts (and at least one when posts exist)", async ({
@@ -33,7 +54,8 @@ test.describe("Homepage LatestPosts section", () => {
     expect(n).toBeGreaterThan(0);
     for (let i = 0; i < n; i++) {
       const href = await links.nth(i).getAttribute("href");
-      expect(href).toMatch(/^\/blog\/[^/]+$/);
+      // Allow nested slugs defensively (post.id may include subpaths in future).
+      expect(href).toMatch(/^\/blog\/.+/);
     }
   });
 
@@ -43,5 +65,54 @@ test.describe("Homepage LatestPosts section", () => {
     );
     await expect(cta).toBeVisible();
     await expect(cta).toHaveAttribute("href", "/blog");
+  });
+
+  test("each post exposes ISO datetime and sr-only language label", async ({
+    page,
+  }) => {
+    const articles = page.locator('[data-testid="latest-posts"] article');
+    const n = await articles.count();
+    expect(n).toBeGreaterThan(0);
+    for (let i = 0; i < n; i++) {
+      const article = articles.nth(i);
+      const iso = await article.locator("time").getAttribute("datetime");
+      expect(iso).not.toBeNull();
+      // ISO 8601 with Z (toISOString() output)
+      expect(iso!).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/);
+      expect(new Date(iso!).toString()).not.toBe("Invalid Date");
+
+      const srOnly = article.locator(".sr-only");
+      const srText = (await srOnly.first().textContent())?.trim() ?? "";
+      expect(srText).toMatch(/Wpis po polsku|Post in English/);
+    }
+  });
+
+  test("clicking a post title tracks Blog Teaser Clicked with slug and position", async ({
+    page,
+  }) => {
+    const link = page
+      .locator('[data-testid="latest-posts"] a[data-blog-teaser-link]')
+      .first();
+    const slug = await link.getAttribute("data-slug");
+    expect(slug).not.toBeNull();
+
+    // Prevent navigation so we can inspect the tracked event.
+    await page.evaluate(() => {
+      document.addEventListener(
+        "click",
+        (e) => {
+          const t = e.target as HTMLElement;
+          if (t.closest("a[data-blog-teaser-link]")) e.preventDefault();
+        },
+        true,
+      );
+    });
+
+    await link.click();
+    const events = await getTrackedEvents(page);
+    expectLastEventToBeTracked(events, TrackingEvents.BLOG_TEASER_CLICKED, {
+      slug,
+      position: 0,
+    });
   });
 });

--- a/tests/latest-posts.spec.ts
+++ b/tests/latest-posts.spec.ts
@@ -1,0 +1,47 @@
+import { expect, test } from "@playwright/test";
+import { acceptConsentIfVisible } from "./helpers/mixpanel";
+
+test.describe("Homepage LatestPosts section", () => {
+  test.beforeEach(async ({ page, baseURL }) => {
+    await page.goto(baseURL!);
+    await acceptConsentIfVisible(page);
+  });
+
+  test("renders between Hero and About", async ({ page }) => {
+    const section = page.locator('[data-testid="latest-posts"]');
+    await expect(section).toBeVisible();
+    await expect(
+      section.getByRole("heading", { name: "Z bloga" }),
+    ).toBeVisible();
+  });
+
+  test("shows at most 3 posts (and at least one when posts exist)", async ({
+    page,
+  }) => {
+    const section = page.locator('[data-testid="latest-posts"]');
+    const articles = section.locator("article");
+    const count = await articles.count();
+    expect(count).toBeGreaterThan(0);
+    expect(count).toBeLessThanOrEqual(3);
+  });
+
+  test("each post link resolves to /blog/:slug", async ({ page }) => {
+    const links = page.locator(
+      '[data-testid="latest-posts"] a[data-blog-teaser-link]',
+    );
+    const n = await links.count();
+    expect(n).toBeGreaterThan(0);
+    for (let i = 0; i < n; i++) {
+      const href = await links.nth(i).getAttribute("href");
+      expect(href).toMatch(/^\/blog\/[^/]+$/);
+    }
+  });
+
+  test('"Wszystkie wpisy" CTA links to /blog', async ({ page }) => {
+    const cta = page.locator(
+      '[data-testid="latest-posts"] a[data-blog-teaser-view-all]',
+    );
+    await expect(cta).toBeVisible();
+    await expect(cta).toHaveAttribute("href", "/blog");
+  });
+});


### PR DESCRIPTION
Closes #370.

## What
Homepage blog sneak peek: 3 most recent published posts rendered between `<Hero />` and `<About />`.

## Changes
- `src/components/LatestPosts.astro` — new section per locked spec in #370:
  - Title, `<time datetime>` (DD.MM.YYYY, pl-PL), language flag (visible emoji `aria-hidden`, sr-only label), excerpt (`line-clamp-1 lg:line-clamp-2`), up to 3 tag chips reusing `/blog` style.
  - Title-only `<a>` (SR-friendly), animated left-to-right underline, `text-orange` on hover/focus, `prefers-reduced-motion` respected.
  - Hairline dividers via `divide-y border-black/10 dark:border-white/10`, `py-6 lg:py-8`.
  - 'Wszystkie wpisy →' CTA → `/blog` (arrow `translate-x-1` on hover).
  - Empty state mirrors `/blog` (orange pencil icon).
- `src/components/ui/SectionTitle.astro` — optional `subtitle` slot (no fork of existing styles).
- `src/lib/tracking.ts` — `BLOG_TEASER_CLICKED` (`{ slug, position }`) and `BLOG_TEASER_VIEW_ALL_CLICKED`, wired via existing `trackClick` helper.
- `src/pages/index.astro` — mounted between Hero and About.
- `tests/latest-posts.spec.ts` — render, count ≤ 3, `/blog/:slug` hrefs, CTA href.

## Verification
- [x] `npm run lint` clean
- [x] `npm run build` green
- [x] `npx playwright test --project=chromium` — 70 passed, 1 pre-existing skip
- [ ] Manual Mixpanel-debug check of `BLOG_TEASER_CLICKED` and `BLOG_TEASER_VIEW_ALL_CLICKED`
- [ ] Visual review against the design note from spike #368

## Notes
WebKit project fails locally with "Executable doesn't exist" — environment (`npx playwright install` needed), not code. CI should be fine.