### PR TITLE
content(blog): Gdy halucynacja staje się prawdą

### DIFF
--- a/src/content/blog/gdy-halucynacja-staje-sie-prawda.md
+++ b/src/content/blog/gdy-halucynacja-staje-sie-prawda.md
@@ -1,0 +1,65 @@
+---
+title: "Gdy halucynacja staje się prawdą: O ślepych trafach algorytmów i koszmarze ewaluacji LLM-ów"
+date: 2026-07-07
+excerpt: "Gemini wymyślił wydarzenie, którego oficjalnie nie było. A jednak telebim stał na plaży i ludzie kibicowali. Historia o tym, jak losowy strzał algorytmu zamienił się w fascynujący edge case z pogranicza ewaluacji AI."
+tags: ["LLM", "Hallucination", "Evals", "AI", "Edge Case"]
+lang: pl
+draft: false
+---
+
+Hiszpania to zdecydowanie moje miejsce na ziemi. Ostatnie wakacje wypadły akurat w terminie meczu Hiszpania-Austria, a znając trochę tutejszą kulturę, postanowiłam zapytać Gemini, czy może gdzieś organizowana jest jakaś strefa kibica. Coś w stylu tych, które pamiętamy z Euro 2012.
+
+Zadaję więc pytanie, jako najzwyklejszy użytkownik, czy coś się dzisiaj dzieje. Model odpowiada pewnie: no jasne, pewka! Na plaży Platja de la Fossa stoi ogromny telebim, mecz startuje o 21:00, zbierają się tłumy.
+
+Pytam o źródło.
+
+Model robi zwrot o 180 stopni. Przyznaje, że wszystko zmyślił. Połączył fakt, że mecz faktycznie się odbywa, z typowymi letnimi atrakcjami w hiszpańskich kurortach i bezpodstawnie wymyślił detale o telebimie na Platja de la Fossa. Sprawdził w wyszukiwarce. Oficjalny kalendarz imprez miasta Calpe na lipiec nie wspominał o żadnej strefie kibica ani wydarzeniu na plaży. Halucynacja. Klasyczna, podręcznikowa. Model przyznał się bez bicia.
+
+Poszłam więc oglądać mecz w pobliskiej knajpce, idę promenadą a tam:
+
+**Telebim stał. Dokładnie tam, gdzie model powiedział.**
+
+Co zrobiłby zwykły użytkownik? Byłby zachwycony. Co robi tester LLM-ów? Zaczyna się niepokoić, bo właśnie zderzył się z jednym z najbardziej podchwytliwych edge case'ów w świecie AI: trafieniem probabilistycznym, które w metrykach ewaluacji powinno być błędem, a w rzeczywistości okazało się prawdą 🤯.
+
+---
+
+## Anatomia "szczęśliwego trafu", czyli jak działa niedeterminizm
+
+Z punktu widzenia architektury LLM, model nie "wiedział", że telebim tam stoi. Modele nie mają intuicji ani ukrytych oczu w świecie fizycznym. To, co się wydarzyło, to czysta matematyka i rozkład prawdopodobieństwa tokenów w przestrzeni wektorowej.
+
+Kiedy sieć neuronowa budowała odpowiedź, algorytm musiał zmapować intencję zapytania na realia geograficzne. Calpe to miasto o ograniczonej liczbie masowych punktów orientacyjnych. W danych treningowych zbitka słów "Calpe + wydarzenie + plaża" najsilniej koreluje z Platja de la Fossa, która statystycznie dominuje w kontekście letnich atrakcji turystycznych. Z kolei ludzka logika organizatorów eventów działa podobnie do wag statystycznych modelu - jeśli robisz wielką strefę kibica w Calpe, robisz ją na największej, najbardziej dostępnej plaży.
+
+Model niczego nie wyszukał. Wygenerował najbardziej prawdopodobny scenariusz, a rzeczywistość idealnie się pod ten scenariusz podłożyła.
+
+---
+
+## Koszmar ewaluacyjny: Pass czy Fail?
+
+Dla osób zajmujących się automatyzacją testów i ewaluacją systemów opartych o LLM-y, taka sytuacja to czysty paradoks. Spójrzmy na to przez pryzmat metryk, które stosujemy w systemach ewaluacji AI.
+
+**Faithfulness / Grounding** - jeśli nasz system ewaluacyjny porównałby odpowiedź modelu z dokumentem kontekstowym - czyli oficjalnym kalendarzem miejskim Calpe na lipiec - wynik byłby jednoznaczny: **0/1, FAIL**. Model wymyślił encję, której nie było w dostarczonym kontekście.
+
+**Real-world Accuracy** - gdyby ktoś pojechał sprawdzić na miejscu: **1/1, PASS**. Telebim stał.
+
+Ten sam output. Dwa różne wyniki oceny.
+
+I tu pojawia się fundamentalne pytanie: jak oceniać systemy, które podają poprawne odpowiedzi z całkowicie błędnych powodów?
+
+Tu leży sedno paradoksu. Hallucination Detection zadziałał poprawnie - to był TRUE POSITIVE. Mechanizm był błędny: model nie miał grounding, wymyślił encję bez pokrycia w źródłach. Eval pipeline oceniał pierwotną odpowiedź, zanim model przyznał się do halucynacji po pytaniu o źródło. Grounding eval wystawił FAIL słusznie. Ale treść odpowiedzi okazała się zgodna z rzeczywistością - i użytkownik, który stanął przed telebimem, dostałby PASS. W systemach asystenckich to zabawna anegdota. W systemach medycznych, prawnych czy finansowych - śmiertelne niebezpieczeństwo. "Szczęśliwy traf" w dawkowaniu leku wciąż pozostaje krytycznym błędem systemu, nawet jeśli pacjent poczuł się lepiej.
+
+
+## Wnioski z plaży w Calpe
+
+Niedeterminizm generatywnego AI potrafi oczarować i zaskoczyć. Jednak jako inżynierowie jakości nie możemy dać się upić tym sukcesem.
+
+Projektując systemy produkcyjne, naszym zadaniem jest eliminacja ślepego trafu na rzecz powtarzalnej, dającej się udowodnić prawdy. Bo jutro model może z tą samą pewnością siebie wskazać telebim na plaży, której w ogóle nie ma - i wtedy użytkownik zamiast strefy kibica zastanie jedynie szum fal.
+
+Kilka pytań, które warto zadać sobie przy projektowaniu ewaluacji:
+
+- Czy twój eval mierzy tylko grounding, czy też real-world accuracy? Jeśli tylko jedno - znasz już swoje ślepe punkty.
+- Czy masz mechanizm oznaczania odpowiedzi "nie do zweryfikowania w czasie oceny"? Brak tej kategorii to źródło fałszywych wniosków o jakości systemu.
+- Czy rozróżniasz błąd mechanizmu od błędu wyniku? Przypadkowa poprawna odpowiedź to nie sukces - to luka w przewidywalności.
+
+Halucynacja, która okazała się prawdą, to rzadki edge case. Ale to właśnie takie momenty weryfikują, czy twój system ewaluacji jest naprawdę przemyślany.
+
+*Vamos España! I udanych testów dla wszystkich.* 🇪🇸

--- a/src/content/blog/gdy-halucynacja-staje-sie-prawda.md
+++ b/src/content/blog/gdy-halucynacja-staje-sie-prawda.md
@@ -47,7 +47,6 @@ I tu pojawia się fundamentalne pytanie: jak oceniać systemy, które podają po
 
 Tu leży sedno paradoksu. Hallucination Detection zadziałał poprawnie - to był TRUE POSITIVE. Mechanizm był błędny: model nie miał grounding, wymyślił encję bez pokrycia w źródłach. Eval pipeline oceniał pierwotną odpowiedź, zanim model przyznał się do halucynacji po pytaniu o źródło. Grounding eval wystawił FAIL słusznie. Ale treść odpowiedzi okazała się zgodna z rzeczywistością - i użytkownik, który stanął przed telebimem, dostałby PASS. W systemach asystenckich to zabawna anegdota. W systemach medycznych, prawnych czy finansowych - śmiertelne niebezpieczeństwo. "Szczęśliwy traf" w dawkowaniu leku wciąż pozostaje krytycznym błędem systemu, nawet jeśli pacjent poczuł się lepiej.
 
-
 ## Wnioski z plaży w Calpe
 
 Niedeterminizm generatywnego AI potrafi oczarować i zaskoczyć. Jednak jako inżynierowie jakości nie możemy dać się upić tym sukcesem.
@@ -62,4 +61,4 @@ Kilka pytań, które warto zadać sobie przy projektowaniu ewaluacji:
 
 Halucynacja, która okazała się prawdą, to rzadki edge case. Ale to właśnie takie momenty weryfikują, czy twój system ewaluacji jest naprawdę przemyślany.
 
-*Vamos España! I udanych testów dla wszystkich.* 🇪🇸
+_Vamos España! I udanych testów dla wszystkich._ 🇪🇸

--- a/src/content/offers/konsultacje.md
+++ b/src/content/offers/konsultacje.md
@@ -6,49 +6,50 @@ tags: ["mentoring", "1:1", "AI"]
 mode: "waitlist"
 ---
 
-Czujesz, że stoisz w miejscu ze swoim rozwojem w IT? Chcesz awansować na stanowisko Mid/Senior, świadomie poruszać się w świecie automatyzacji i wreszcie przestać udawać, że rozumiesz, czym są MCP, agenci AI, RAG czy zaawansowany prompt engineering?
+Masz dość bycia traktowanym jako "wykonawca testów" na końcu procesu produkcyjnego? Chcesz wreszcie zacząć dyktować architekturę, realnie zarządzać jakością i stać się dla biznesu partnerem z prawdziwego zdarzenia?
 
-To nie są klasyczne "korepetycje z programowania" ani sprawdzanie kodu linijka po linijce. To **strategiczny mentoring kariery i procesów**, którego celem jest demistyfikacja AI, zbudowanie Twojej niezależności jako Inżyniera Jakości i przygotowanie Cię na realia dzisiejszego rynku IT.
+Mój mentoring to proces, w którym pomagam inżynierom takim jak Ty wejść na wyższy, liderski poziom. Skupiamy się na tym, co naprawdę liczy się na dzisiejszym rynku: budowaniu nowoczesnej architektury, strategicznym podejściu do jakości i sprytnym wykorzystaniu sztucznej inteligencji w codziennej pracy.
 
-## Twój ekosystem rozwoju
+## Autorski Framework Architekta Kariery
 
-To, co najmocniej wyróżnia ten program, dzieje się **poza** sesją wideo. Każda osoba pod moimi skrzydłami otrzymuje spersonalizowane środowisko pracy.
+Wierzę, że największa wartość w mentoringu powstaje poza naszą godzinną sesją wideo. Dlatego opracowałam proces, który daje Ci konkretne ramy do rozwoju i bardzo ułatwia codzienną pracę w projekcie.
 
-### Dedykowane repozytorium na GitHubie
+### Prywatni Asystenci AI i gotowe Prompty
 
-Dla każdej osoby zakładam w pełni prywatne repozytorium - Twój osobisty hub wiedzy. Trafiają tam notatki z sesji, strategie rekrutacyjne, szablony i ustawienia narzędzi. Masz do tego ciągły dostęp, a wszystko jest uporządkowane w jednym miejscu, do którego wracasz długo po zakończeniu współpracy.
+Zamiast tylko rozmawiać o potędze AI, pomogę Ci wdrożyć ją w praktyce. Skonfiguruję dla Ciebie gotowe "Skille" (prompty) dobrane pod Twoje konkretne zadania. Zbudujemy narzędzia, które przejmą powtarzalne i nużące taski, pomogą Ci symulować trudne rozmowy (np. trudny feedback z managerem na 1:1) i po prostu pozwolą zaoszczędzić Ci mnóstwo czasu w każdym tygodniu.
 
-### Spersonalizowane reguły AI
+### Strategia i umiejętności biznesowe
 
-Przestaniesz traktować AI jako "magię", a zaczniesz jak narzędzie pracy. W Twoim repozytorium konfiguruję **AI rules** (system prompty, skille, agenty) dopasowane do Twojego konkretnego celu - przygotowania do rekrutacji, nauki nowego frameworka czy automatyzacji powtarzalnej pracy QA. Pokazuję, jak asystenci AI mogą znać Twój kontekst od pierwszej minuty rozmowy.
+Pracujemy nad kompetencjami, których nie znajdziesz w dokumentacji technicznej. Pokażę Ci, jak zoptymalizować profil na LinkedIn, przygotować się do trudnych rekrutacji na stanowiska Senior/Lead i przećwiczyć asertywne negocjacje. Uczysz się, jak rozmawiać o stawkach i świadomie budować swoją pozycję w zespole.
 
-### Stałe wsparcie na zamkniętym Discordzie
+### Twoje osobiste repozytorium na GitHubie
 
-Rozwój nie kończy się na godzinnej rozmowie wideo. Otrzymujesz dostęp do prywatnej przestrzeni na Discordzie, gdzie analizujemy oferty pracy, dyskutujemy o strategii, odpowiadamy na szybkie pytania i świętujemy Twoje sukcesy.
+Na start zakładam dla Ciebie prywatne repozytorium. To Twój hub wiedzy – trafiają tam precyzyjne notatki z naszych spotkań, szablony, strategie i konfiguracje narzędzi. Masz wszystko uporządkowane w jednym miejscu i wracasz do tego długo po zakończeniu naszej współpracy.
 
-### Strategia, biznes i pewność siebie
+### Bezpośrednie wsparcie komunikacyjne
 
-Uczę tego, czego nie znajdziesz w dokumentacji technicznej. Rozmawiamy o tym, jak komunikować się z biznesem, jak rozpoznawać i odrzucać toksyczne oferty pracy, jak pozycjonować swoje kompetencje na rynku napędzanym przez AI. Wspólnie optymalizujemy LinkedIna, przygotowujemy "ściągi rekrutacyjne" i ćwiczymy asertywne negocjacje finansowe.
+Twój rozwój nie pauzuje między spotkaniami. Masz priorytetowy dostęp do prywatnego kanału, na którym asynchronicznie rozwiązujemy pożary w Twoim projekcie i omawiamy postępy. 
 
-## Dla kogo to jest
+## Dla kogo to jest?
 
-- **Testerzy**, którzy chcą uporządkować wiedzę o AI, zrozumieć Agentów, MCP i LLM-y, i zintegrować te narzędzia z codzienną pracą - żeby pracować sprytniej, nie ciężej.
-- **QA Engineers**, którzy chcą odejść od "wyklikiwania" i stać się świadomymi partnerami w zespole produktowym (Shift-Left Testing).
-- **Specjaliści szukający stabilnej pracy** w firmach produktowych - którzy chcą mądrze poprowadzić rekrutację i wynegocjować lepsze stawki (B2B/UoP).
+- **Ambitnych QA i Testerów**, którzy chcą awansować do ról Mid/Senior lub Lead, porzucić ręczne "wyklikiwanie" na rzecz asystentów AI i po prostu zacząć pracować sprytniej, a nie ciężej.
+- **Obecnych i aspirujących Liderów**, którzy chcą zyskać realny wpływ na organizację (Shift-Left Testing), poukładać procesy od zera i zbudować autorytet w zespole.
+- **Specjalistów B2B/UoP**, którzy chcą świadomie kierować swoją karierą, przyciągać lepsze oferty pracy i poczuć się znacznie pewniej w negocjacjach.
 
-## Jak wygląda współpraca
+## Jak wygląda współpraca?
 
-**Pakiet startowy** (onboarding + sesja strategiczna) to nasze pierwsze spotkanie i pełne wdrożenie w nowy ekosystem nauki:
+**Faza Setupu (Onboarding + Sesja Strategiczna)**
 
-- 60-minutowa sesja wideo: audyt potrzeb, ustalenie celów, ułożenie planu rozwoju.
-- Praca asynchroniczna przed i po sesji: założenie i konfiguracja Twojego prywatnego repozytorium.
-- Spersonalizowane reguły AI dobrane pod Twój cel, wgrane do repozytorium.
-- Zaproszenie do prywatnego kanału na Discordzie.
+To pierwszy krok – solidne wdrożenie i ułożenie naszego planu gry:
 
-**Sesje kontynuacyjne** to praca na rozgrzanym silniku:
+- 60-minutowa sesja wideo: głęboki audyt Twojej obecnej sytuacji projektowej i wyznaczenie priorytetów.
+- Praca asynchroniczna przed i po sesji: w tym czasie uzbrajam Twoje repozytorium w pierwsze, przydatne szablony.
+- Otwarcie dostępu do prywatnego kanału komunikacji.
 
-- 60-minutowa sesja wideo skupiona na realizacji planu.
-- Analiza Twoich postępów z pracy własnej (np. przegląd interakcji z AI).
-- Bieżące Q&A na Discordzie pomiędzy sesjami (w granicach zdrowego rozsądku).
+**Współpraca ciągła (Sesje Kontynuacyjne)**
 
-Cennik i szczegóły organizacyjne omawiamy indywidualnie podczas rozmowy kwalifikacyjnej - dopasowuję zakres do Twojego celu.
+- 60-minutowe spotkania wideo, na których weryfikujemy założenia z planu i pracujemy nad nowymi celami.
+- Analiza postępów i iteracyjna praca np. nad doskonaleniem Twoich narzędzi AI.
+- Bieżące wsparcie asynchroniczne, żebyś mógł na bieżąco konsultować sytuacje ze swojej firmy.
+
+*Cennik i model współpracy ustalamy wspólnie podczas niezobowiązującej rozmowy. Zakres zawsze dobieram indywidualnie – tak, aby odpowiadał na Twoje cele i możliwości czasowe.*

--- a/src/content/offers/konsultacje.md
+++ b/src/content/offers/konsultacje.md
@@ -28,7 +28,7 @@ Na start zakładam dla Ciebie prywatne repozytorium. To Twój hub wiedzy – tra
 
 ### Bezpośrednie wsparcie komunikacyjne
 
-Twój rozwój nie pauzuje między spotkaniami. Masz priorytetowy dostęp do prywatnego kanału, na którym asynchronicznie rozwiązujemy pożary w Twoim projekcie i omawiamy postępy. 
+Twój rozwój nie pauzuje między spotkaniami. Masz priorytetowy dostęp do prywatnego kanału, na którym asynchronicznie rozwiązujemy pożary w Twoim projekcie i omawiamy postępy.
 
 ## Dla kogo to jest?
 
@@ -52,4 +52,4 @@ To pierwszy krok – solidne wdrożenie i ułożenie naszego planu gry:
 - Analiza postępów i iteracyjna praca np. nad doskonaleniem Twoich narzędzi AI.
 - Bieżące wsparcie asynchroniczne, żebyś mógł na bieżąco konsultować sytuacje ze swojej firmy.
 
-*Cennik i model współpracy ustalamy wspólnie podczas niezobowiązującej rozmowy. Zakres zawsze dobieram indywidualnie – tak, aby odpowiadał na Twoje cele i możliwości czasowe.*
+_Cennik i model współpracy ustalamy wspólnie podczas niezobowiązującej rozmowy. Zakres zawsze dobieram indywidualnie – tak, aby odpowiadał na Twoje cele i możliwości czasowe._


### PR DESCRIPTION
## Nowy artykuł na bloga

**Tytuł:** Gdy halucynacja staje się prawdą: O ślepych trafach algorytmów i koszmarze ewaluacji LLM-ów

### O czym jest artykuł
Osobista historia z wakacji w Calpe - Gemini z pełnym przekonaniem odpowiedział na pytanie o strefę kibica, podając konkretne miejsce na plaży. Model przyznał się do halucynacji po pytaniu o źródło. Telebim jednak stał dokładnie tam, gdzie model powiedział.

Artykuł analizuje ten edge case przez pryzmat ewaluacji LLM-ów: paradoks, w którym Hallucination Detection zadziałał poprawnie (TRUE POSITIVE, brak grounding = FAIL), ale treść odpowiedzi okazała się zgodna z rzeczywistością (real-world accuracy = PASS).

### Zmiany
- Nowy plik: `src/content/blog/gdy-halucynacja-staje-sie-prawda.md`
- `draft: false` - gotowy do publikacji