### PR TITLE
feat: YouTube thumbnails + dedykowana sekcja MediaPresence

### DIFF
--- a/src/components/LatestPosts.astro
+++ b/src/components/LatestPosts.astro
@@ -13,7 +13,7 @@ const latestPosts = posts
 
 <section
   data-testid="latest-posts"
-  class="w-full bg-gray-50 py-16 dark:bg-gray-950 lg:py-24"
+  class="w-full py-16 lg:py-24"
 >
   <div class="mx-auto w-full max-w-3xl px-4">
     <SectionTitle>

--- a/src/components/MediaPresence.astro
+++ b/src/components/MediaPresence.astro
@@ -1,0 +1,126 @@
+---
+import { Icon } from "astro-icon/components";
+import SectionTitle from "@components/ui/SectionTitle.astro";
+import cvData from "@data/cv.json";
+
+const talks = cvData.talks ?? [];
+
+function getYouTubeId(url: string): string | null {
+  const match = url.match(/[?&]v=([^&]+)/);
+  return match ? match[1] : null;
+}
+---
+
+{
+  talks.length > 0 && (
+    <section
+      data-testid="media-presence"
+      id="media-presence"
+      class="w-full bg-gray-50 py-16 dark:bg-gray-950 lg:py-24"
+    >
+      <div class="mx-auto w-full max-w-6xl px-4">
+        <SectionTitle>
+          Usłyszysz mnie też w
+          <Fragment slot="subtitle">
+            Wideo i podcasty o testowaniu, AI i jakości
+          </Fragment>
+        </SectionTitle>
+
+        <div class="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
+          {talks.map((talk) => {
+            const links = talk.links ?? [];
+            const youtubeLink = links.find((l) =>
+              l.url.includes("youtube.com")
+            );
+            const otherLinks = links.filter(
+              (l) => !l.url.includes("youtube.com")
+            );
+            const youtubeId = youtubeLink
+              ? getYouTubeId(youtubeLink.url)
+              : null;
+            const label = talk.episode
+              ? `${talk.show} • ${talk.episode}`
+              : talk.show;
+
+            return (
+              <div>
+                {youtubeId && youtubeLink ? (
+                  <div
+                    data-testid="media-presence-card"
+                    class="group h-full overflow-hidden rounded-xl bg-white shadow-md transition-all hover:-translate-y-1 hover:shadow-xl dark:bg-gray-800"
+                  >
+                    <a
+                      href={youtubeLink.url}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      title={talk.summary ?? ""}
+                      class="block"
+                    >
+                      <div class="relative aspect-video w-full overflow-hidden bg-gray-200 dark:bg-gray-700">
+                        <img
+                          src={`https://img.youtube.com/vi/${youtubeId}/mqdefault.jpg`}
+                          alt={talk.title}
+                          class="h-full w-full object-cover transition-transform duration-300 group-hover:scale-105"
+                          loading="lazy"
+                        />
+                        <div class="absolute inset-0 flex items-center justify-center bg-black/30 opacity-0 transition-opacity duration-300 group-hover:opacity-100">
+                          <div class="flex h-12 w-12 items-center justify-center rounded-full bg-red-600 shadow-lg">
+                            <Icon
+                              name="simple-icons:youtube"
+                              class="h-6 w-6 text-white"
+                            />
+                          </div>
+                        </div>
+                      </div>
+                      <div class="px-3 pt-3">
+                        <p class="text-xs font-semibold text-orange">{label}</p>
+                        <p class="mt-1 line-clamp-2 text-sm font-medium text-gray-800 dark:text-gray-100">
+                          {talk.title}
+                        </p>
+                        {talk.date && (
+                          <p class="mt-1 text-xs text-gray-500 dark:text-gray-400">
+                            {talk.date}
+                          </p>
+                        )}
+                      </div>
+                    </a>
+                    {otherLinks.length > 0 && (
+                      <div class="flex flex-wrap gap-2 px-3 pb-3 pt-2">
+                        {otherLinks.map((ol) => (
+                          <a
+                            href={ol.url}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            title={ol.label}
+                            class="inline-flex items-center gap-1 rounded-full bg-gray-100 px-2 py-1 text-xs text-gray-600 hover:bg-orange/10 hover:text-orange dark:bg-gray-700 dark:text-gray-300 dark:hover:bg-orange/20 dark:hover:text-orange"
+                          >
+                            <Icon name={ol.icon} class="h-3 w-3" />
+                            {ol.label}
+                          </a>
+                        ))}
+                      </div>
+                    )}
+                  </div>
+                ) : (
+                  links.map((l) => (
+                    <a
+                      data-testid="media-presence-card"
+                      href={l.url}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      title={talk.summary ?? ""}
+                      class="inline-flex items-center gap-2 rounded-full bg-white px-4 py-2 text-sm text-black shadow-sm hover:bg-orange/10 hover:text-orange dark:bg-gray-800 dark:text-white dark:hover:bg-orange/20 dark:hover:text-orange"
+                    >
+                      <Icon name={l.icon} class="h-4 w-4" />
+                      <span>{label}</span>
+                    </a>
+                  ))
+                )}
+              </div>
+            );
+          })}
+        </div>
+      </div>
+    </section>
+  )
+}

--- a/src/components/MediaPresence.astro
+++ b/src/components/MediaPresence.astro
@@ -5,9 +5,15 @@ import cvData from "@data/cv.json";
 
 const talks = cvData.talks ?? [];
 
+function isYouTubeUrl(url: string): boolean {
+  return url.includes("youtube.com") || url.includes("youtu.be");
+}
+
 function getYouTubeId(url: string): string | null {
-  const match = url.match(/[?&]v=([^&]+)/);
-  return match ? match[1] : null;
+  const watch = url.match(/[?&]v=([^&#]+)/);
+  if (watch) return watch[1];
+  const short = url.match(/youtu\.be\/([^?&#]+)/);
+  return short ? short[1] : null;
 }
 ---
 
@@ -29,12 +35,8 @@ function getYouTubeId(url: string): string | null {
         <div class="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
           {talks.map((talk) => {
             const links = talk.links ?? [];
-            const youtubeLink = links.find((l) =>
-              l.url.includes("youtube.com")
-            );
-            const otherLinks = links.filter(
-              (l) => !l.url.includes("youtube.com")
-            );
+            const youtubeLink = links.find((l) => isYouTubeUrl(l.url));
+            const otherLinks = links.filter((l) => !isYouTubeUrl(l.url));
             const youtubeId = youtubeLink
               ? getYouTubeId(youtubeLink.url)
               : null;
@@ -53,7 +55,7 @@ function getYouTubeId(url: string): string | null {
                       href={youtubeLink.url}
                       target="_blank"
                       rel="noopener noreferrer"
-                      title={talk.summary ?? ""}
+                      title={talk.summary ?? talk.title}
                       class="block"
                     >
                       <div class="relative aspect-video w-full overflow-hidden bg-gray-200 dark:bg-gray-700">
@@ -102,19 +104,34 @@ function getYouTubeId(url: string): string | null {
                     )}
                   </div>
                 ) : (
-                  links.map((l) => (
-                    <a
-                      data-testid="media-presence-card"
-                      href={l.url}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      title={talk.summary ?? ""}
-                      class="inline-flex items-center gap-2 rounded-full bg-white px-4 py-2 text-sm text-black shadow-sm hover:bg-orange/10 hover:text-orange dark:bg-gray-800 dark:text-white dark:hover:bg-orange/20 dark:hover:text-orange"
-                    >
-                      <Icon name={l.icon} class="h-4 w-4" />
-                      <span>{label}</span>
-                    </a>
-                  ))
+                  <div
+                    data-testid="media-presence-card"
+                    class="flex h-full flex-col rounded-xl bg-white p-4 shadow-md transition-all hover:-translate-y-1 hover:shadow-xl dark:bg-gray-800"
+                  >
+                    <p class="text-xs font-semibold text-orange">{label}</p>
+                    <p class="mt-1 line-clamp-2 text-sm font-medium text-gray-800 dark:text-gray-100">
+                      {talk.title}
+                    </p>
+                    {talk.date && (
+                      <p class="mt-1 text-xs text-gray-500 dark:text-gray-400">
+                        {talk.date}
+                      </p>
+                    )}
+                    <div class="mt-3 flex flex-wrap gap-2">
+                      {links.map((l) => (
+                        <a
+                          href={l.url}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          title={l.label}
+                          class="inline-flex items-center gap-1 rounded-full bg-gray-100 px-2 py-1 text-xs text-gray-600 hover:bg-orange/10 hover:text-orange dark:bg-gray-700 dark:text-gray-300 dark:hover:bg-orange/20 dark:hover:text-orange"
+                        >
+                          <Icon name={l.icon} class="h-3 w-3" />
+                          {l.label}
+                        </a>
+                      ))}
+                    </div>
+                  </div>
                 )}
               </div>
             );

--- a/src/components/SocialProof.astro
+++ b/src/components/SocialProof.astro
@@ -1,7 +1,5 @@
 ---
-import { Icon } from "astro-icon/components";
 import SectionTitle from "@components/ui/SectionTitle.astro";
-import cvData from "@data/cv.json";
 
 const testimonials = [
   {
@@ -26,7 +24,7 @@ const testimonials = [
 <section
   data-testid="social-proof"
   id="social-proof"
-  class="w-full bg-gray-50 py-16 dark:bg-gray-950 lg:py-24"
+  class="w-full py-16 lg:py-24"
 >
   <div class="mx-auto w-full max-w-6xl px-4">
     <SectionTitle>Co mówią inni</SectionTitle>

--- a/src/components/SocialProof.astro
+++ b/src/components/SocialProof.astro
@@ -21,8 +21,6 @@ const testimonials = [
       "Michalina has been an incredible support to every team member - always approachable, always encouraging, and deeply committed to everyone's success.",
   },
 ];
-
-const talks = cvData.talks ?? [];
 ---
 
 <section
@@ -31,7 +29,7 @@ const talks = cvData.talks ?? [];
   class="w-full bg-gray-50 py-16 dark:bg-gray-950 lg:py-24"
 >
   <div class="mx-auto w-full max-w-6xl px-4">
-    <SectionTitle>Społeczność</SectionTitle>
+    <SectionTitle>Co mówią inni</SectionTitle>
 
     <div class="flex w-full flex-col gap-6 md:flex-row md:gap-8">
       {
@@ -60,39 +58,5 @@ const talks = cvData.talks ?? [];
         ))
       }
     </div>
-
-    {
-      talks.length > 0 && (
-        <div class="mt-12">
-          <h3 class="mb-4 text-sm font-semibold uppercase tracking-wide text-gray-600 dark:text-gray-400">
-            Usłyszysz mnie też w
-          </h3>
-          <ul class="flex flex-wrap gap-3">
-            {talks.map((talk) => {
-              const primaryLink = (talk.links ?? [])[0];
-              if (!primaryLink) return null;
-              const label = talk.episode
-                ? `${talk.show} • ${talk.episode}`
-                : talk.show;
-              return (
-                <li>
-                  <a
-                    data-testid="social-proof-media-pill"
-                    href={primaryLink.url}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    title={talk.summary ?? ""}
-                    class="inline-flex items-center gap-2 rounded-full bg-white px-4 py-2 text-sm text-black shadow-sm hover:bg-orange/10 hover:text-orange dark:bg-gray-800 dark:text-white dark:hover:bg-orange/20 dark:hover:text-orange"
-                  >
-                    <Icon name={primaryLink.icon} class="h-4 w-4" />
-                    <span>{label}</span>
-                  </a>
-                </li>
-              );
-            })}
-          </ul>
-        </div>
-      )
-    }
   </div>
 </section>

--- a/src/data/cv.json
+++ b/src/data/cv.json
@@ -126,6 +126,22 @@
   ],
   "talks": [
     {
+      "title": "Dlaczego AI nie słucha komend jak pies? Walka z niedeterministycznością w testach LLM",
+      "show": "AI Testers",
+      "episode": "Odc. 1",
+      "host": null,
+      "date": "lip 2026",
+      "lang": "pl",
+      "summary": "Pierwszy odcinek serii AI Testers: dlaczego testowanie LLM-ów to nie to samo co testowanie klasycznego oprogramowania i jak radzić sobie z niedeterministycznością.",
+      "links": [
+        {
+          "label": "YouTube",
+          "url": "https://www.youtube.com/watch?v=hxE-qr7whzE",
+          "icon": "simple-icons:youtube"
+        }
+      ]
+    },
+    {
       "title": "O testowaniu asystenta AI, pracy w InPost i nowych kierunkach QA",
       "show": "Testing Station",
       "episode": "S03E01",

--- a/src/pages/cv.astro
+++ b/src/pages/cv.astro
@@ -112,7 +112,7 @@ import cvData from "@data/cv.json";
         <div class="space-y-6 text-black dark:text-white">
           {
             (cvData.talks ?? []).map((talk) => (
-              <div>
+              <article>
                 <h3 class="text-xl font-bold">{talk.title}</h3>
                 <p class="text-orange">
                   {talk.show}
@@ -136,7 +136,7 @@ import cvData from "@data/cv.json";
                     </a>
                   ))}
                 </div>
-              </div>
+              </article>
             ))
           }
         </div>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -3,6 +3,7 @@ import About from "@components/About.astro";
 import Contact from "@components/Contact.astro";
 import Hero from "@components/Hero.astro";
 import LatestPosts from "@components/LatestPosts.astro";
+import MediaPresence from "@components/MediaPresence.astro";
 import Offers from "@components/Offers.astro";
 import SocialProof from "@components/SocialProof.astro";
 import BackToTop from "@components/ui/BackToTop.astro";
@@ -25,10 +26,11 @@ const personSchema = {
   <script type="application/ld+json" set:html={JSON.stringify(personSchema)} />
   <main id="main-content">
     <Hero />
-    <LatestPosts />
     <About />
-    <Offers />
+    <MediaPresence />
     <SocialProof />
+    <Offers />
+    <LatestPosts />
     <Contact />
     <BackToTop />
   </main>

--- a/tests/content.spec.ts
+++ b/tests/content.spec.ts
@@ -37,21 +37,17 @@ test.describe("Page Content", () => {
     }
   });
 
-  test("SocialProof media strip shows Testing Station with primary listen link", async ({
+  test("MediaPresence strip shows Testing Station with primary listen link", async ({
     page,
   }) => {
-    const sp = page.locator('[data-testid="social-proof"]');
-    await expect(sp).toBeVisible();
-    await expect(sp.getByText("Testing Station")).toBeVisible();
+    const mp = page.locator('[data-testid="media-presence"]');
+    await expect(mp).toBeVisible();
+    await expect(mp.getByText("Testing Station")).toBeVisible();
 
-    const pills = sp.locator('[data-testid="social-proof-media-pill"]');
-    await expect(pills).not.toHaveCount(0);
-    // The primary link for the Testing Station talk is the YouTube URL
-    // (first entry in talk.links in cv.json).
-    await expect(pills.first()).toHaveAttribute(
-      "href",
-      "https://www.youtube.com/watch?v=H9tyKlE9Hzc",
+    const testingStationLink = mp.locator(
+      'a[href="https://www.youtube.com/watch?v=H9tyKlE9Hzc"]',
     );
+    await expect(testingStationLink).toBeVisible();
   });
 
   test("Blog page has correct meta description", async ({ page, baseURL }) => {

--- a/tests/content.spec.ts
+++ b/tests/content.spec.ts
@@ -82,8 +82,8 @@ test.describe("Page Content", () => {
       const sp = page.locator('[data-testid="social-proof"]');
       await expect(sp).toBeVisible();
 
-      // Section title (single h2 covers both testimonials and media)
-      await expect(sp.locator("h2")).toHaveText("Społeczność");
+      // Section title (testimonials only; media lives in MediaPresence)
+      await expect(sp.locator("h2")).toHaveText("Co mówią inni");
 
       // Testimonial cards
       const testimonialCards = sp.locator(

--- a/tests/cv.spec.ts
+++ b/tests/cv.spec.ts
@@ -98,23 +98,27 @@ test.describe("CV Page", () => {
       }),
     ).toBeVisible();
 
-    const talksSection = page
-      .getByRole("heading", { name: "Wystąpienia" })
-      .locator("xpath=ancestor::section");
+    const testingStationTalk = talksSection
+      .locator("article")
+      .filter({
+        hasText:
+          "O testowaniu asystenta AI, pracy w InPost i nowych kierunkach QA",
+      });
 
-    await expect(talksSection.getByText("Testing Station")).toBeVisible();
+    await expect(testingStationTalk).toBeVisible();
+    await expect(testingStationTalk.getByText("Testing Station")).toBeVisible();
 
     await expect(
-      talksSection.getByRole("link", { name: "YouTube" }),
+      testingStationTalk.getByRole("link", { name: "YouTube" }),
     ).toHaveAttribute("href", "https://www.youtube.com/watch?v=H9tyKlE9Hzc");
     await expect(
-      talksSection.getByRole("link", { name: "Spotify" }),
+      testingStationTalk.getByRole("link", { name: "Spotify" }),
     ).toHaveAttribute(
       "href",
       "https://open.spotify.com/episode/5ycBXVusQImSyjXmkne3mu",
     );
     await expect(
-      talksSection.getByRole("link", { name: "Apple Podcasts" }),
+      testingStationTalk.getByRole("link", { name: "Apple Podcasts" }),
     ).toHaveAttribute(
       "href",
       "https://podcasts.apple.com/us/podcast/21-o-testowaniu-asystenta-ai-pracy-w-inpost-i-nowych/id1801809925?i=1000766797678",

--- a/tests/cv.spec.ts
+++ b/tests/cv.spec.ts
@@ -98,12 +98,10 @@ test.describe("CV Page", () => {
       }),
     ).toBeVisible();
 
-    const testingStationTalk = talksSection
-      .locator("article")
-      .filter({
-        hasText:
-          "O testowaniu asystenta AI, pracy w InPost i nowych kierunkach QA",
-      });
+    const testingStationTalk = talksSection.locator("article").filter({
+      hasText:
+        "O testowaniu asystenta AI, pracy w InPost i nowych kierunkach QA",
+    });
 
     await expect(testingStationTalk).toBeVisible();
     await expect(testingStationTalk.getByText("Testing Station")).toBeVisible();

--- a/tests/cv.spec.ts
+++ b/tests/cv.spec.ts
@@ -98,6 +98,10 @@ test.describe("CV Page", () => {
       }),
     ).toBeVisible();
 
+    const talksSection = page
+      .getByRole("heading", { name: "Wystąpienia" })
+      .locator("xpath=ancestor::section");
+
     const testingStationTalk = talksSection.locator("article").filter({
       hasText:
         "O testowaniu asystenta AI, pracy w InPost i nowych kierunkach QA",

--- a/tests/homepage-rhythm.spec.ts
+++ b/tests/homepage-rhythm.spec.ts
@@ -27,12 +27,9 @@ test.describe("Homepage section rhythm", () => {
       await acceptConsentIfVisible(page);
     });
 
-    const tintedSections = [
-      "latest-posts",
-      "offers",
-      "social-proof",
-      "media-presence",
-    ] as const;
+    // Tints alternate through the middle band so no two tinted sections sit
+    // back-to-back and merge into one gray slab.
+    const tintedSections = ["media-presence", "offers"] as const;
 
     for (const id of tintedSections) {
       test(`'${id}' carries the tinted background class`, async ({ page }) => {
@@ -42,8 +39,14 @@ test.describe("Homepage section rhythm", () => {
       });
     }
 
-    const anchorSections = ["hero", "about", "contact"] as const;
-    for (const id of anchorSections) {
+    const untintedSections = [
+      "hero",
+      "about",
+      "social-proof",
+      "latest-posts",
+      "contact",
+    ] as const;
+    for (const id of untintedSections) {
       test(`'${id}' does NOT carry the tinted background class`, async ({
         page,
       }) => {

--- a/tests/homepage-rhythm.spec.ts
+++ b/tests/homepage-rhythm.spec.ts
@@ -2,24 +2,6 @@ import { expect, test } from "@playwright/test";
 import { acceptConsentIfVisible } from "./helpers/mixpanel";
 
 test.describe("Homepage section rhythm", () => {
-  test.describe("Hero tightening", () => {
-    test.use({ viewport: { width: 1280, height: 800 } });
-
-    test("LatestPosts H2 is within viewport on 1280x800 desktop", async ({
-      page,
-      baseURL,
-    }) => {
-      await page.goto(baseURL!);
-      await acceptConsentIfVisible(page);
-
-      const heading = page
-        .locator('[data-testid="latest-posts"]')
-        .getByRole("heading", { level: 2 });
-      const box = await heading.boundingBox();
-      expect(box).not.toBeNull();
-      expect(box!.y).toBeLessThan(800);
-    });
-  });
 
   test.describe("About no longer claims full viewport", () => {
     test.use({ viewport: { width: 1280, height: 800 } });
@@ -46,7 +28,7 @@ test.describe("Homepage section rhythm", () => {
       await acceptConsentIfVisible(page);
     });
 
-    const tintedSections = ["latest-posts", "offers", "social-proof"] as const;
+    const tintedSections = ["latest-posts", "offers", "social-proof", "media-presence"] as const;
 
     for (const id of tintedSections) {
       test(`'${id}' carries the tinted background class`, async ({ page }) => {
@@ -70,7 +52,7 @@ test.describe("Homepage section rhythm", () => {
   });
 
   test.describe("Section count and order", () => {
-    test("page renders exactly the 6 expected sections in order", async ({
+    test("page renders exactly the 7 expected sections in order", async ({
       page,
       baseURL,
     }) => {
@@ -79,10 +61,11 @@ test.describe("Homepage section rhythm", () => {
 
       const expected = [
         "hero",
-        "latest-posts",
         "about",
-        "offers",
+        "media-presence",
         "social-proof",
+        "offers",
+        "latest-posts",
         "contact",
       ];
 

--- a/tests/homepage-rhythm.spec.ts
+++ b/tests/homepage-rhythm.spec.ts
@@ -2,7 +2,6 @@ import { expect, test } from "@playwright/test";
 import { acceptConsentIfVisible } from "./helpers/mixpanel";
 
 test.describe("Homepage section rhythm", () => {
-
   test.describe("About no longer claims full viewport", () => {
     test.use({ viewport: { width: 1280, height: 800 } });
 
@@ -28,7 +27,12 @@ test.describe("Homepage section rhythm", () => {
       await acceptConsentIfVisible(page);
     });
 
-    const tintedSections = ["latest-posts", "offers", "social-proof", "media-presence"] as const;
+    const tintedSections = [
+      "latest-posts",
+      "offers",
+      "social-proof",
+      "media-presence",
+    ] as const;
 
     for (const id of tintedSections) {
       test(`'${id}' carries the tinted background class`, async ({ page }) => {

--- a/tests/latest-posts.spec.ts
+++ b/tests/latest-posts.spec.ts
@@ -12,30 +12,6 @@ test.describe("Homepage LatestPosts section", () => {
     await acceptConsentIfVisible(page);
   });
 
-  test("renders in DOM order: Hero → LatestPosts → About", async ({ page }) => {
-    const section = page.locator('[data-testid="latest-posts"]');
-    await expect(section).toBeVisible();
-    await expect(
-      section.getByRole("heading", { name: "Z bloga" }),
-    ).toBeVisible();
-
-    const order = await page.evaluate(() => {
-      const ids = ["hero", "latest-posts", "about"];
-      const tops = ids.map((id) => {
-        const el =
-          document.querySelector(`[data-testid="${id}"]`) ??
-          document.getElementById(id);
-        return el ? el.getBoundingClientRect().top + window.scrollY : null;
-      });
-      return tops;
-    });
-    expect(order[0]).not.toBeNull();
-    expect(order[1]).not.toBeNull();
-    expect(order[2]).not.toBeNull();
-    expect(order[0]!).toBeLessThan(order[1]!);
-    expect(order[1]!).toBeLessThan(order[2]!);
-  });
-
   test("shows at most 3 posts (and at least one when posts exist)", async ({
     page,
   }) => {

--- a/tests/social-proof.spec.ts
+++ b/tests/social-proof.spec.ts
@@ -28,28 +28,35 @@ test.describe("Homepage SocialProof section", () => {
     ).toHaveCount(2);
   });
 
-  test("renders a media-appearance pill per talk in cv.json", async ({
+  test("renders media-appearance cards in the dedicated MediaPresence section", async ({
     page,
   }) => {
-    const sp = page.locator('[data-testid="social-proof"]');
-    const pills = sp.locator('[data-testid="social-proof-media-pill"]');
-    await expect(pills).not.toHaveCount(0);
-    const count = await pills.count();
+    const mp = page.locator('[data-testid="media-presence"]');
+    await expect(mp).toBeVisible();
+    const cards = mp.locator('[data-testid="media-presence-card"]');
+    await expect(cards).not.toHaveCount(0);
+  });
+
+  test("each media card links to an external URL with target=_blank", async ({
+    page,
+  }) => {
+    const cards = page.locator('[data-testid="media-presence-card"]');
+    const count = await cards.count();
     for (let i = 0; i < count; i++) {
-      const pill = pills.nth(i);
-      await expect(pill).toHaveAttribute("target", "_blank");
-      const href = await pill.getAttribute("href");
+      const card = cards.nth(i);
+      await expect(card).toHaveAttribute("target", "_blank");
+      const href = await card.getAttribute("href");
       expect(href).toMatch(/^https?:\/\//);
     }
   });
 
-  test("each media pill carries the talk summary as a title attribute", async ({
+  test("each media card carries the talk summary as a title attribute", async ({
     page,
   }) => {
-    const pills = page.locator('[data-testid="social-proof-media-pill"]');
-    const count = await pills.count();
+    const cards = page.locator('[data-testid="media-presence-card"]');
+    const count = await cards.count();
     for (let i = 0; i < count; i++) {
-      const title = await pills.nth(i).getAttribute("title");
+      const title = await cards.nth(i).getAttribute("title");
       expect(title?.length ?? 0).toBeGreaterThan(0);
     }
   });

--- a/tests/social-proof.spec.ts
+++ b/tests/social-proof.spec.ts
@@ -37,26 +37,24 @@ test.describe("Homepage SocialProof section", () => {
     await expect(cards).not.toHaveCount(0);
   });
 
-  test("each media card links to an external URL with target=_blank", async ({
+  test("each media link points to an external URL with target=_blank", async ({
     page,
   }) => {
-    const cards = page.locator('[data-testid="media-presence-card"]');
-    const count = await cards.count();
+    const links = page.locator('[data-testid="media-presence"] a');
+    const count = await links.count();
     for (let i = 0; i < count; i++) {
-      const card = cards.nth(i);
-      await expect(card).toHaveAttribute("target", "_blank");
-      const href = await card.getAttribute("href");
+      const link = links.nth(i);
+      await expect(link).toHaveAttribute("target", "_blank");
+      const href = await link.getAttribute("href");
       expect(href).toMatch(/^https?:\/\//);
     }
   });
 
-  test("each media card carries the talk summary as a title attribute", async ({
-    page,
-  }) => {
-    const cards = page.locator('[data-testid="media-presence-card"]');
-    const count = await cards.count();
+  test("each media link carries a title attribute", async ({ page }) => {
+    const links = page.locator('[data-testid="media-presence"] a');
+    const count = await links.count();
     for (let i = 0; i < count; i++) {
-      const title = await cards.nth(i).getAttribute("title");
+      const title = await links.nth(i).getAttribute("title");
       expect(title?.length ?? 0).toBeGreaterThan(0);
     }
   });


### PR DESCRIPTION
## Co robi ten PR

Dodaje miniaturki YouTube do strony głównej i reorganizuje układ sekcji dla lepszej konwersji.

## Zmiany

### Nowe pliki
- **`MediaPresence.astro`** — dedykowana pełnoszerokościowa sekcja z gridem filmów/podcastów (gotowa na 7 filmów), responsywny układ 1→2→3→4 kolumny

### Zmodyfikowane pliki
- **`cv.json`** — dodano nowy wpis: AI Testers Odc. 1 (`hxE-qr7whzE`)
- **`SocialProof.astro`** — zawiera teraz wyłącznie testimoniale, tytuł zmieniony na _Co mówią inni_
- **`About.astro`** — przywrócony do czystego układu: zdjęcie + bio
- **`index.astro`** — nowa kolejność sekcji

## Nowy układ strony

```
Hero → O mnie → Usłyszysz mnie też w → Co mówią inni → Oferta → Z bloga → Kontakt
```

Logika: poznaj → autorytet → zaufanie → konwersja → retencja

## Szczegóły techniczne
- Miniaturki YouTube pobierane przez `img.youtube.com/vi/{id}/mqdefault.jpg` (bez API key)
- Hover overlay z przyciskiem play
- Naprawiono błąd zagnieżdżonego `<a>` w `<a>` (invalid HTML)
- Daty na kartach wideo