### PR TITLE
docs: adopt Simplified Technical English (ASD-STE100) for English prose

### DIFF
--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -20,3 +20,10 @@ npm run test:local
 ```
 
 When making changes, add or update tests in `tests/` to cover your changes.
+
+## Writing style
+
+English prose — docs, code comments, commit and PR text, issues, user-visible strings —
+follows [Simplified Technical English](https://www.asd-ste100.org/) (ASD-STE100): one
+meaning per word, active voice, imperative for instructions, simple tenses, one
+instruction per sentence (max 20 words), no jargon or metaphor. Code identifiers are exempt.


### PR DESCRIPTION
One paragraph in the agent file requiring [Simplified Technical English](https://www.asd-ste100.org/) (ASD-STE100) for English prose — docs, code comments, commit and PR text, issues, user-visible strings. Code identifiers are exempt.

Kept to the rules that actually change output rather than restating all 53; the standard is linked for the rest.

Docs-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)